### PR TITLE
Add remaining tests for Kafka - StrimziMetricsReporter and refactor class names

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -109,7 +109,7 @@
         </module>
         <module name="ClassDataAbstractionCoupling">
             <!-- default is 7 -->
-            <property name="max" value="20"/>
+            <property name="max" value="23"/>
         </module>
         <module name="BooleanExpressionComplexity">
             <!-- default is 3 -->

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/MetricsConfig.java
@@ -23,7 +23,7 @@ import java.util.Map;
         property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(name = JmxPrometheusExporterMetrics.TYPE_JMX_EXPORTER, value = JmxPrometheusExporterMetrics.class),
-    @JsonSubTypes.Type(name = StrimziReporterMetrics.TYPE_STRIMZI_REPORTER_METRICS, value = StrimziReporterMetrics.class)
+    @JsonSubTypes.Type(name = StrimziMetricsReporter.TYPE_STRIMZI_REPORTER_METRICS, value = StrimziMetricsReporter.class)
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporter.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporter.java
@@ -23,10 +23,10 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class StrimziReporterMetrics extends MetricsConfig {
+public class StrimziMetricsReporter extends MetricsConfig {
     public static final String TYPE_STRIMZI_REPORTER_METRICS = "strimziMetricsReporter";
 
-    private StrimziReporterValues values;
+    private StrimziMetricsReporterValues values;
 
     @Description("Must be `" + TYPE_STRIMZI_REPORTER_METRICS + "`")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -36,11 +36,11 @@ public class StrimziReporterMetrics extends MetricsConfig {
     }
 
     @Description("Configuration values for the Strimzi Metrics Reporter.")
-    public StrimziReporterValues getValues() {
+    public StrimziMetricsReporterValues getValues() {
         return values;
     }
 
-    public void setValues(StrimziReporterValues values) {
+    public void setValues(StrimziMetricsReporterValues values) {
         this.values = values;
     }
 }

--- a/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporterValues.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporterValues.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @JsonPropertyOrder({"allowList"})
 @EqualsAndHashCode()
 @ToString
-public class StrimziReporterValues implements UnknownPropertyPreserving {
+public class StrimziMetricsReporterValues implements UnknownPropertyPreserving {
     private static final String DEFAULT_REGEX = ".*";
 
     private List<String> allowList = List.of(DEFAULT_REGEX);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -30,7 +30,7 @@ import io.strimzi.api.kafka.model.kafka.tieredstorage.TieredStorageCustom;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.kafka.oauth.server.plain.ServerPlainConfig;
 import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsReporter;
-import io.strimzi.operator.cluster.model.metrics.StrimziReporterMetricsModel;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 
@@ -136,16 +136,16 @@ public class KafkaBrokerConfigurationBuilder {
     /**
      * Configures the Strimzi Metrics Reporter. It is set only if user enabled Strimzi Metrics Reporter.
      *
-     * @param model     Cruise Control Metrics Reporter configuration
+     * @param model     Strimzi Metrics Reporter configuration
      *
      * @return Returns the builder instance
      */
-    public KafkaBrokerConfigurationBuilder withStrimziMetricsReporter(StrimziReporterMetricsModel model)   {
+    public KafkaBrokerConfigurationBuilder withStrimziMetricsReporter(StrimziMetricsReporterModel model)   {
         if (model != null && model.isEnabled()) {
             printSectionHeader("Strimzi Metrics Reporter configuration");
             writer.println("kafka.metrics.reporters=io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter");
             writer.println("prometheus.metrics.reporter.listener.enable=true");
-            writer.println("prometheus.metrics.reporter.listener=http://0.0.0.0:" + StrimziReporterMetricsModel.METRICS_PORT);
+            writer.println("prometheus.metrics.reporter.listener=http://0.0.0.0:" + StrimziMetricsReporterModel.METRICS_PORT);
             model.getAllowList().ifPresent(allowList -> writer.println("prometheus.metrics.reporter.allowlist=" + allowList));
             writer.println();
         }
@@ -828,7 +828,7 @@ public class KafkaBrokerConfigurationBuilder {
                 metricReporters = appendMetricReporter(metricReporters, CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER);
             }
             if (injectStrimziMetricsReporter) {
-                metricReporters = appendMetricReporter(metricReporters, StrimziReporterMetricsModel.KAFKA_PROMETHEUS_METRICS_REPORTER);
+                metricReporters = appendMetricReporter(metricReporters, StrimziMetricsReporterModel.KAFKA_PROMETHEUS_METRICS_REPORTER);
             }
             if (metricReporters != null) {
                 // update the userConfig with the new list of metric reporters
@@ -850,7 +850,7 @@ public class KafkaBrokerConfigurationBuilder {
                     metricReporters = CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER;
                 }
                 if (injectStrimziMetricsReporter) {
-                    metricReporters = appendMetricReporter(metricReporters, StrimziReporterMetricsModel.KAFKA_PROMETHEUS_METRICS_REPORTER);
+                    metricReporters = appendMetricReporter(metricReporters, StrimziMetricsReporterModel.KAFKA_PROMETHEUS_METRICS_REPORTER);
                 }
                 writer.println(KafkaCluster.KAFKA_METRIC_REPORTERS_CONFIG_FIELD + "=" + metricReporters);
                 writer.println();

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
@@ -5,7 +5,7 @@
 package io.strimzi.operator.cluster.model.metrics;
 
 import io.strimzi.api.kafka.model.common.HasConfigurableMetrics;
-import io.strimzi.api.kafka.model.common.metrics.StrimziReporterMetrics;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
 import io.strimzi.operator.common.model.InvalidResourceException;
 
 import java.util.ArrayList;
@@ -17,7 +17,7 @@ import java.util.regex.PatternSyntaxException;
 /**
  * Represents a model for components with configurable metrics using Strimzi Reporter
  */
-public class StrimziReporterMetricsModel {
+public class StrimziMetricsReporterModel {
     /**
      * Fully Qualified Class Name of the Strimzi Kafka Prometheus Metrics Reporter.
      */
@@ -40,9 +40,9 @@ public class StrimziReporterMetricsModel {
      *
      * @param spec StrimziReporterMetrics object containing the metrics configuration
      */
-    public StrimziReporterMetricsModel(HasConfigurableMetrics spec) {
+    public StrimziMetricsReporterModel(HasConfigurableMetrics spec) {
         if (spec.getMetricsConfig() != null) {
-            if (spec.getMetricsConfig() instanceof StrimziReporterMetrics config) {
+            if (spec.getMetricsConfig() instanceof StrimziMetricsReporter config) {
                 validate(config);
                 this.isEnabled = true;
                 this.allowList = config.getValues() != null &&
@@ -69,7 +69,7 @@ public class StrimziReporterMetricsModel {
      *
      * @param config StrimziReporterMetrics configuration to validate
      */
-    /* test */ static void validate(StrimziReporterMetrics config) {
+    /* test */ static void validate(StrimziMetricsReporter config) {
         List<String> errors = new ArrayList<>();
         if (config.getValues() != null && config.getValues().getAllowList() != null) {
             if (config.getValues().getAllowList().isEmpty()) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -7,12 +7,15 @@ package io.strimzi.operator.cluster.model;
 import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.Rack;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloakBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationOpaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationSimpleBuilder;
+import io.strimzi.api.kafka.model.kafka.KafkaClusterSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.kafka.Storage;
@@ -32,7 +35,7 @@ import io.strimzi.api.kafka.model.kafka.tieredstorage.TieredStorageCustom;
 import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsReporter;
-import io.strimzi.operator.cluster.model.metrics.StrimziReporterMetricsModel;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
 import io.strimzi.test.annotations.ParallelSuite;
@@ -153,6 +156,22 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         assertThat(configuration, isEquivalent("node.id=2"));
+    }
+
+    @ParallelTest
+    public void testStrimziMetricsReporter() {
+        StrimziMetricsReporter metricsConfig = new StrimziMetricsReporterBuilder().build();
+        StrimziMetricsReporterModel strimziMetricsReporter = new StrimziMetricsReporterModel(new KafkaClusterSpecBuilder()
+                .withMetricsConfig(metricsConfig).build());
+
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF)
+                .withStrimziMetricsReporter(strimziMetricsReporter)
+                .build();
+
+        assertThat(configuration, isEquivalent("node.id=2",
+                 "kafka.metrics.reporters=io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter",
+                 "prometheus.metrics.reporter.listener.enable=true",
+                 "prometheus.metrics.reporter.listener=http://0.0.0.0:9404"));
     }
 
     @ParallelTest
@@ -512,7 +531,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
-                "metric.reporters=" + StrimziReporterMetricsModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
+                "metric.reporters=" + StrimziMetricsReporterModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
     }
 
     @ParallelTest
@@ -530,7 +549,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "metric.reporters=" + CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER
-                        + "," + StrimziReporterMetricsModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
+                        + "," + StrimziMetricsReporterModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
     }
 
     @ParallelTest
@@ -640,7 +659,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "offsets.topic.replication.factor=3",
                 "transaction.state.log.replication.factor=3",
                 "transaction.state.log.min.isr=2",
-                "metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"));
+                KafkaCluster.KAFKA_METRIC_REPORTERS_CONFIG_FIELD + "=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter"));
     }
 
     @ParallelTest
@@ -682,7 +701,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
-                "metric.reporters=my.domain.CustomMetricReporter," + StrimziReporterMetricsModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
+                "metric.reporters=my.domain.CustomMetricReporter," + StrimziMetricsReporterModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
     }
 
     @ParallelTest
@@ -704,7 +723,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "metric.reporters=my.domain.CustomMetricReporter,"
                         + CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER + ","
-                        + StrimziReporterMetricsModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
+                        + StrimziMetricsReporterModel.KAFKA_PROMETHEUS_METRICS_REPORTER));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -303,6 +303,30 @@ public class KafkaClusterTest {
     }
 
     @ParallelTest
+    public void testStrimziMetricsConfigs() {
+        Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withNewStrimziMetricsReporterConfig()
+                            .withNewValues()
+                                .withAllowList("kafka_log.*", "kafka_network.*")
+                            .endValues()
+                        .endStrimziMetricsReporterConfig()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
+        KafkaCluster kafkaCluster = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
+        String brokerConfig = kafkaCluster.generatePerBrokerConfiguration(1, ADVERTISED_HOSTNAMES, ADVERTISED_PORTS);
+
+        assertThat(brokerConfig, containsString("kafka.metrics.reporters=io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"));
+        assertThat(brokerConfig, containsString("prometheus.metrics.reporter.listener.enable=true"));
+        assertThat(brokerConfig, containsString("prometheus.metrics.reporter.listener=http://0.0.0.0:9404"));
+        assertThat(brokerConfig, containsString("allowlist=kafka_log.*,kafka_network.*"));
+    }
+
+    @ParallelTest
     public void  testJavaSystemProperties() {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
@@ -950,22 +974,7 @@ public class KafkaClusterTest {
         }));
     }
 
-    @ParallelTest
-    public void testContainerPorts() {
-        Kafka kafka = new KafkaBuilder(KAFKA)
-                .editSpec()
-                    .editKafka()
-                        .withListeners(new GenericKafkaListenerBuilder().withName("tls").withPort(9093).withType(KafkaListenerType.INTERNAL).withTls().build(),
-                                new GenericKafkaListenerBuilder().withName("external").withPort(9094).withType(KafkaListenerType.NODEPORT).withTls().build())
-                        .withNewJmxPrometheusExporterMetricsConfig()
-                            .withNewValueFrom()
-                                .withNewConfigMapKeyRef("metrics-cm", "metrics.json", false)
-                            .endValueFrom()
-                        .endJmxPrometheusExporterMetricsConfig()
-                    .endKafka()
-                .endSpec()
-                .build();
-
+    private void testContainerPorts(Kafka kafka) {
         List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, SHARED_ENV_PROVIDER);
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
         List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, node -> Map.of());
@@ -996,6 +1005,45 @@ public class KafkaClusterTest {
             }
         }));
     }
+
+    @ParallelTest
+    public void testWithJmxMetricsExporterContainerPorts() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder().withName("tls").withPort(9093).withType(KafkaListenerType.INTERNAL).withTls().build(),
+                                new GenericKafkaListenerBuilder().withName("external").withPort(9094).withType(KafkaListenerType.NODEPORT).withTls().build())
+                        .withNewJmxPrometheusExporterMetricsConfig()
+                            .withNewValueFrom()
+                                .withNewConfigMapKeyRef("metrics-cm", "metrics.json", false)
+                            .endValueFrom()
+                        .endJmxPrometheusExporterMetricsConfig()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        testContainerPorts(kafka);
+    }
+
+    @ParallelTest
+    public void testWithStrimziMetricsReporterContainerPorts() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withListeners(new GenericKafkaListenerBuilder().withName("tls").withPort(9093).withType(KafkaListenerType.INTERNAL).withTls().build(),
+                                new GenericKafkaListenerBuilder().withName("external").withPort(9094).withType(KafkaListenerType.NODEPORT).withTls().build())
+                        .withNewStrimziMetricsReporterConfig()
+                            .withNewValues()
+                                .withAllowList("kafka_log.*", "kafka_network.*")
+                            .endValues()
+                        .endStrimziMetricsReporterConfig()
+                    .endKafka()
+                .endSpec()
+                .build();
+
+        testContainerPorts(kafka);
+    }
+
 
     @ParallelTest
     public void testAuxiliaryResourcesTemplate() {
@@ -1952,7 +2000,7 @@ public class KafkaClusterTest {
     @ParallelTest
     public void testMetricsParsingNoMetrics() {
         assertThat(KC.metrics(), is(nullValue()));
-        assertThat(KC.strimziReporterMetrics(), is(nullValue()));
+        assertThat(KC.strimziMetricsReporter(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
@@ -4,8 +4,8 @@
  */
 package io.strimzi.operator.cluster.model.metrics;
 
-import io.strimzi.api.kafka.model.common.metrics.StrimziReporterMetrics;
-import io.strimzi.api.kafka.model.common.metrics.StrimziReporterMetricsBuilder;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaClusterSpecBuilder;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Assertions;
@@ -20,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class StrimziReporterMetricsModelTest {
+public class StrimziMetricsReporterModelTest {
 
     @Test
     public void testDisabled() {
-        StrimziReporterMetricsModel metrics = new StrimziReporterMetricsModel(new KafkaClusterSpecBuilder().build());
+        StrimziMetricsReporterModel metrics = new StrimziMetricsReporterModel(new KafkaClusterSpecBuilder().build());
 
         assertThat(metrics.isEnabled(), is(false));
         assertThat(metrics.getAllowList(), is(Optional.empty()));
@@ -32,12 +32,12 @@ public class StrimziReporterMetricsModelTest {
 
     @Test
     public void testEnabled() {
-        StrimziReporterMetrics metricsConfig = new StrimziReporterMetricsBuilder()
+        StrimziMetricsReporter metricsConfig = new StrimziMetricsReporterBuilder()
                 .withNewValues()
                     .withAllowList(List.of("kafka_log.*", "kafka_network.*"))
                 .endValues()
                 .build();
-        StrimziReporterMetricsModel metrics = new StrimziReporterMetricsModel(new KafkaClusterSpecBuilder()
+        StrimziMetricsReporterModel metrics = new StrimziMetricsReporterModel(new KafkaClusterSpecBuilder()
                 .withMetricsConfig(metricsConfig).build());
 
         assertThat(metrics.isEnabled(), is(true));
@@ -47,15 +47,15 @@ public class StrimziReporterMetricsModelTest {
 
     @Test
     public void testValidation() {
-        assertDoesNotThrow(() -> StrimziReporterMetricsModel.validate(new StrimziReporterMetricsBuilder()
+        assertDoesNotThrow(() -> StrimziMetricsReporterModel.validate(new StrimziMetricsReporterBuilder()
                 .withNewValues()
                     .withAllowList(List.of("kafka_log.*", "kafka_network.*"))
                 .endValues()
                 .build())
         );
 
-        InvalidResourceException ise0 = assertThrows(InvalidResourceException.class, () -> StrimziReporterMetricsModel.validate(
-                new StrimziReporterMetricsBuilder()
+        InvalidResourceException ise0 = assertThrows(InvalidResourceException.class, () -> StrimziMetricsReporterModel.validate(
+                new StrimziMetricsReporterBuilder()
                         .withNewValues()
                         .withAllowList(List.of())
                         .endValues()
@@ -64,8 +64,8 @@ public class StrimziReporterMetricsModelTest {
         assertThat(ise0.getMessage(), is("Metrics configuration is invalid: [Allowlist should contain at least one element]"));
 
 
-        InvalidResourceException ise1 = Assertions.assertThrows(InvalidResourceException.class, () -> StrimziReporterMetricsModel.validate(
-                new StrimziReporterMetricsBuilder()
+        InvalidResourceException ise1 = Assertions.assertThrows(InvalidResourceException.class, () -> StrimziMetricsReporterModel.validate(
+                new StrimziMetricsReporterBuilder()
                         .withNewValues()
                         .withAllowList(List.of("kafka_network.*", "kafka_log.***", "[a+"))
                         .endValues()

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -116,7 +116,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc[leveloffs
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core[ResourceRequirements]
 |CPU and memory resources to reserve.
 |metricsConfig
-|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziReporterMetrics-{context}[`StrimziReporterMetrics`]
+|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 |Metrics configuration.
 |logging
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
@@ -1020,7 +1020,7 @@ It must have the value `password` for the type `KafkaJmxAuthenticationPassword`.
 Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
-The `type` property is a discriminator that distinguishes use of the `JmxPrometheusExporterMetrics` type from xref:type-StrimziReporterMetrics-{context}[`StrimziReporterMetrics`].
+The `type` property is a discriminator that distinguishes use of the `JmxPrometheusExporterMetrics` type from xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`].
 It must have the value `jmxPrometheusExporter` for the type `JmxPrometheusExporterMetrics`.
 [cols="2,2,3a",options="header"]
 |====
@@ -1047,14 +1047,14 @@ Used in: xref:type-ExternalLogging-{context}[`ExternalLogging`], xref:type-JmxPr
 |Reference to the key in the ConfigMap containing the configuration.
 |====
 
-[id='type-StrimziReporterMetrics-{context}']
-= `StrimziReporterMetrics` schema reference
+[id='type-StrimziMetricsReporter-{context}']
+= `StrimziMetricsReporter` schema reference
 
 Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`], xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`], xref:type-KafkaConnectSpec-{context}[`KafkaConnectSpec`], xref:type-KafkaMirrorMaker2Spec-{context}[`KafkaMirrorMaker2Spec`], xref:type-ZookeeperClusterSpec-{context}[`ZookeeperClusterSpec`]
 
 
-The `type` property is a discriminator that distinguishes use of the `StrimziReporterMetrics` type from xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`].
-It must have the value `strimziMetricsReporter` for the type `StrimziReporterMetrics`.
+The `type` property is a discriminator that distinguishes use of the `StrimziMetricsReporter` type from xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`].
+It must have the value `strimziMetricsReporter` for the type `StrimziMetricsReporter`.
 [cols="2,2,3a",options="header"]
 |====
 |Property |Property type |Description
@@ -1062,14 +1062,14 @@ It must have the value `strimziMetricsReporter` for the type `StrimziReporterMet
 |string
 |Must be `strimziMetricsReporter`.
 |values
-|xref:type-StrimziReporterValues-{context}[`StrimziReporterValues`]
+|xref:type-StrimziMetricsReporterValues-{context}[`StrimziMetricsReporterValues`]
 |Configuration values for the Strimzi Metrics Reporter.
 |====
 
-[id='type-StrimziReporterValues-{context}']
-= `StrimziReporterValues` schema reference
+[id='type-StrimziMetricsReporterValues-{context}']
+= `StrimziMetricsReporterValues` schema reference
 
-Used in: xref:type-StrimziReporterMetrics-{context}[`StrimziReporterMetrics`]
+Used in: xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 
 
 [cols="2,2,3a",options="header"]
@@ -1585,7 +1585,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core[ResourceRequirements]
 |CPU and memory resources to reserve.
 |metricsConfig
-|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziReporterMetrics-{context}[`StrimziReporterMetrics`]
+|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 |Metrics configuration.
 |logging
 |xref:type-InlineLogging-{context}[`InlineLogging`], xref:type-ExternalLogging-{context}[`ExternalLogging`]
@@ -1937,7 +1937,7 @@ include::../api/io.strimzi.api.kafka.model.kafka.cruisecontrol.CruiseControlSpec
 |map
 |The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, capacity.config.file, self.healing., ssl., kafka.broker.failure.detection.enable, topic.config.provider.class (with the exception of: ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, webserver.http.cors.enabled, webserver.http.cors.origin, webserver.http.cors.exposeheaders, webserver.security.enable, webserver.ssl.enable).
 |metricsConfig
-|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziReporterMetrics-{context}[`StrimziReporterMetrics`]
+|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 |Metrics configuration.
 |apiUsers
 |xref:type-HashLoginServiceApiUsers-{context}[`HashLoginServiceApiUsers`]
@@ -2526,7 +2526,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |xref:type-Rack-{context}[`Rack`]
 |Configuration of the node label which will be used as the `client.rack` consumer configuration.
 |metricsConfig
-|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziReporterMetrics-{context}[`StrimziReporterMetrics`]
+|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 |Metrics configuration.
 |tracing
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
@@ -4121,7 +4121,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |xref:type-Rack-{context}[`Rack`]
 |Configuration of the node label which will be used as the `client.rack` consumer configuration.
 |metricsConfig
-|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziReporterMetrics-{context}[`StrimziReporterMetrics`]
+|xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
 |Metrics configuration.
 |tracing
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the remaining unit tests for the Kafka part of the StrimziMetricsReporter integration.
It also refactors names with StrimziReporterMetrics to StrimziMetricsReporter.

Tests added to the following:
* clusteroperator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
* cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java

Class name changes:
* api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporter.java
* api/src/main/java/io/strimzi/api/kafka/model/common/metrics/StrimziMetricsReporterValues.java
* cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
* cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java

