### PR TITLE
Add metrics model interface

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ConfigMapUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ConfigMapUtils.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.strimzi.operator.cluster.model.logging.SupportsLogging;
-import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.SupportsMetrics;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
@@ -67,10 +67,11 @@ public class ConfigMapUtils {
             data.put(supportsLogging.logging().configMapKey(), supportsLogging.logging().loggingConfiguration(reconciliation, metricsAndLogging.loggingCm()));
         }
 
-        if (model instanceof SupportsMetrics supportMetrics && supportMetrics.metrics() != null) {
-            String parseResult = supportMetrics.metrics().metricsJson(reconciliation, metricsAndLogging.metricsCm());
+        // this is only for JMX Prometheus Exporter, because Strimzi Metrics Reporter configuration is in the Kafka configuration file
+        if (model instanceof SupportsMetrics supportMetrics && supportMetrics.metrics() instanceof JmxPrometheusExporterModel) {
+            String parseResult = ((JmxPrometheusExporterModel) supportMetrics.metrics()).metricsJson(reconciliation, metricsAndLogging.metricsCm());
             if (parseResult != null) {
-                data.put(MetricsModel.CONFIG_MAP_KEY, parseResult);
+                data.put(JmxPrometheusExporterModel.CONFIG_MAP_KEY, parseResult);
             }
         }
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -76,6 +76,7 @@ import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.jmx.SupportsJmx;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.logging.SupportsLogging;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.cluster.model.metrics.SupportsMetrics;
@@ -232,9 +233,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     private String clusterId;
     private JmxModel jmx;
     private CruiseControlMetricsReporter ccMetricsReporter;
-    // new MetricsModel metrics
-    private MetricsModel jmxExporterMetrics;
-    private StrimziMetricsReporterModel strimziMetricsReporter;
+    private MetricsModel metrics;
     private LoggingModel logging;
     private QuotasPlugin quotas;
     /* test */ KafkaConfiguration configuration;
@@ -339,9 +338,9 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         result.initImage = initImage;
 
         if (kafkaClusterSpec.getMetricsConfig() instanceof JmxPrometheusExporterMetrics) {
-            result.jmxExporterMetrics = new MetricsModel(kafkaClusterSpec);
+            result.metrics = new JmxPrometheusExporterModel(kafkaClusterSpec);
         } else if (kafkaClusterSpec.getMetricsConfig() instanceof StrimziMetricsReporter) {
-            result.strimziMetricsReporter = new StrimziMetricsReporterModel(kafkaClusterSpec);
+            result.metrics = new StrimziMetricsReporterModel(kafkaClusterSpec);
         }
 
         result.logging = new LoggingModel(kafkaClusterSpec, result.getClass().getSimpleName(), false, true);
@@ -425,6 +424,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         result.warningConditions.addAll(specChecker.run());
 
         return result;
+    }
+
+    private boolean hasMetricsConfig() {
+        return metrics != null && metrics.isEnabled();
     }
 
     /**
@@ -1322,11 +1325,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         }
 
         // Metrics port is enabled on all node types regardless their role
-        // if metrics instance of
-        if (jmxExporterMetrics != null && jmxExporterMetrics.isEnabled()) {
+        if (hasMetricsConfig()) {
             ports.add(ContainerUtils.createContainerPort(MetricsModel.METRICS_PORT_NAME, MetricsModel.METRICS_PORT));
-        } else if (strimziMetricsReporter != null && strimziMetricsReporter.isEnabled()) {
-            ports.add(ContainerUtils.createContainerPort(StrimziMetricsReporterModel.METRICS_PORT_NAME, StrimziMetricsReporterModel.METRICS_PORT));
         }
 
         // JMX port is enabled on all node types regardless their role
@@ -1640,8 +1640,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      */
     private  List<EnvVar> getEnvVars(KafkaPool pool) {
         List<EnvVar> varList = new ArrayList<>();
-        String jmxMetricsEnabled = jmxExporterMetrics != null && jmxExporterMetrics.isEnabled() ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
-        varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_JMX_EXPORTER_ENABLED, jmxMetricsEnabled));
+        varList.add(ContainerUtils.createEnvVar(ENV_VAR_KAFKA_JMX_EXPORTER_ENABLED,
+            hasMetricsConfig() && metrics instanceof JmxPrometheusExporterModel ? Boolean.TRUE.toString() : Boolean.FALSE.toString()));
         varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(pool.gcLoggingEnabled)));
 
         JvmOptionUtils.heapOptions(varList, 50, 5L * 1024L * 1024L * 1024L, pool.jvmOptions, pool.resources);
@@ -1753,10 +1753,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         }
 
         // The Metrics port (if enabled) is opened to all by default
-        if (jmxExporterMetrics != null && jmxExporterMetrics.isEnabled()) {
+        if (hasMetricsConfig()) {
             rules.add(NetworkPolicyUtils.createIngressRule(MetricsModel.METRICS_PORT, List.of()));
-        } else if (strimziMetricsReporter != null && strimziMetricsReporter.isEnabled()) {
-            rules.add(NetworkPolicyUtils.createIngressRule(StrimziMetricsReporterModel.METRICS_PORT, List.of()));
         }
 
         // The JMX port (if enabled) is opened to all by default
@@ -1841,26 +1839,29 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      * @return  String with the Kafka broker configuration
      */
     private String generatePerBrokerConfiguration(NodeRef node, KafkaPool pool, Map<Integer, Map<String, String>> advertisedHostnames, Map<Integer, Map<String, String>> advertisedPorts)   {
-        return new KafkaBrokerConfigurationBuilder(reconciliation, node)
-                .withRackId(rack)
-                .withKRaft(cluster, namespace, nodes())
-                .withKRaftMetadataLogDir(VolumeUtils.kraftMetadataPath(pool.storage))
-                .withLogDirs(VolumeUtils.createVolumeMounts(pool.storage, false))
-                .withListeners(cluster,
-                        kafkaVersion,
-                        namespace,
-                        listeners,
-                        listenerId -> advertisedHostnames.get(node.nodeId()).get(listenerId),
-                        listenerId -> advertisedPorts.get(node.nodeId()).get(listenerId)
-                )
-                .withAuthorization(cluster, authorization)
-                .withCruiseControl(cluster, ccMetricsReporter, node.broker())
-                .withStrimziMetricsReporter(strimziMetricsReporter)
-                .withTieredStorage(cluster, tieredStorage)
-                .withQuotas(cluster, quotas)
-                .withUserConfiguration(configuration, node.broker() && ccMetricsReporter != null, strimziMetricsReporter != null && strimziMetricsReporter.isEnabled())
-                .build()
-                .trim();
+        KafkaBrokerConfigurationBuilder builder = new KafkaBrokerConfigurationBuilder(reconciliation, node)
+            .withRackId(rack)
+            .withKRaft(cluster, namespace, nodes())
+            .withKRaftMetadataLogDir(VolumeUtils.kraftMetadataPath(pool.storage))
+            .withLogDirs(VolumeUtils.createVolumeMounts(pool.storage, false))
+            .withListeners(cluster,
+                kafkaVersion,
+                namespace,
+                listeners,
+                listenerId -> advertisedHostnames.get(node.nodeId()).get(listenerId),
+                listenerId -> advertisedPorts.get(node.nodeId()).get(listenerId)
+            )
+            .withAuthorization(cluster, authorization)
+            .withCruiseControl(cluster, ccMetricsReporter, node.broker())
+            .withTieredStorage(cluster, tieredStorage)
+            .withQuotas(cluster, quotas);
+        if (hasMetricsConfig() && metrics instanceof StrimziMetricsReporterModel) {
+            builder.withStrimziMetricsReporter((StrimziMetricsReporterModel) metrics)
+                .withUserConfiguration(configuration, node.broker() && ccMetricsReporter != null, true);
+        } else {
+            builder.withUserConfiguration(configuration, node.broker() && ccMetricsReporter != null, false);
+        }
+        return builder.build().trim();
     }
 
     /**
@@ -1873,10 +1874,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      *
      * @return ConfigMap with the shared configuration.
      */
-    public List<ConfigMap> generatePerBrokerConfigurationConfigMaps(MetricsAndLogging metricsAndLogging, Map<Integer, Map<String, String>> advertisedHostnames, Map<Integer, Map<String, String>> advertisedPorts) {
+    public List<ConfigMap> generatePerBrokerConfigurationConfigMaps(MetricsAndLogging metricsAndLogging, Map<Integer, Map<String, String>> advertisedHostnames, Map<Integer, Map<String, String>> advertisedPorts)   {
         String parsedMetrics = null;
-        if (jmxExporterMetrics != null && jmxExporterMetrics.isEnabled()) {
-            parsedMetrics = jmxExporterMetrics.metricsJson(reconciliation, metricsAndLogging.metricsCm());
+        if (hasMetricsConfig() && metrics instanceof JmxPrometheusExporterModel) {
+            parsedMetrics = ((JmxPrometheusExporterModel) metrics).metricsJson(reconciliation, metricsAndLogging.metricsCm());
         }
         String parsedLogging = logging().loggingConfiguration(reconciliation, metricsAndLogging.loggingCm());
         List<ConfigMap> configMaps = new ArrayList<>();
@@ -1886,7 +1887,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 Map<String, String> data = new HashMap<>(4);
 
                 if (parsedMetrics != null) {
-                    data.put(MetricsModel.CONFIG_MAP_KEY, parsedMetrics);
+                    data.put(JmxPrometheusExporterModel.CONFIG_MAP_KEY, parsedMetrics);
                 }
 
                 data.put(logging.configMapKey(), parsedLogging);
@@ -1951,14 +1952,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      * @return  Metrics Model instance for configuring Prometheus metrics
      */
     public MetricsModel metrics()   {
-        return jmxExporterMetrics;
-    }
-
-    /**
-     * @return Strimzi Metrics Reporter Model instance for configuring Prometheus metrics
-     */
-    public StrimziMetricsReporterModel strimziMetricsReporter()   {
-        return strimziMetricsReporter;
+        return metrics;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/JmxPrometheusExporterModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/JmxPrometheusExporterModel.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.metrics;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.strimzi.api.kafka.model.common.HasConfigurableMetrics;
+import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
+import io.strimzi.operator.common.InvalidConfigurationException;
+import io.strimzi.operator.common.Reconciliation;
+import io.strimzi.operator.common.ReconciliationLogger;
+import io.strimzi.operator.common.model.InvalidResourceException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Model for the Prometheus JMX Exporter Java agent.
+ */
+public class JmxPrometheusExporterModel implements MetricsModel {
+    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(JmxPrometheusExporterModel.class.getName());
+
+    /**
+     * Key under which the metrics configuration is stored in the ConfigMap.
+     */
+    public static final String CONFIG_MAP_KEY = "metrics-config.json";
+
+    private final boolean isEnabled;
+    private final String configMapName;
+    private final String configMapKey;
+
+    /**
+     * Constructs the Metrics Model for managing configurable metrics to Strimzi.
+     *
+     * @param spec Custom resource section configuring metrics.
+     */
+    public JmxPrometheusExporterModel(HasConfigurableMetrics spec) {
+        if (spec.getMetricsConfig() != null) {
+            if (spec.getMetricsConfig() instanceof JmxPrometheusExporterMetrics config) {
+                validateJmxExporterMetricsConfig(config);
+                this.isEnabled = true;
+                this.configMapName = config.getValueFrom().getConfigMapKeyRef().getName();
+                this.configMapKey = config.getValueFrom().getConfigMapKeyRef().getKey();
+            } else {
+                throw new InvalidResourceException("Unsupported metrics type " + spec.getMetricsConfig().getType());
+            }
+        } else {
+            this.isEnabled = false;
+            this.configMapName = null;
+            this.configMapKey = null;
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    /**
+     * @return The name of the Config Map with the metrics configuration.
+     */
+    public String getConfigMapName() {
+        return configMapName;
+    }
+
+    /**
+     * @return The key under which the metrics configuration is stored in the Config Map.
+     */
+    public String getConfigMapKey() {
+        return configMapKey;
+    }
+
+    /**
+     * Generates Prometheus metrics configuration based on the JMXExporter configuration from the user-provided ConfigMap.
+     * When metrics are not enabled, returns null.
+     *
+     * @param reconciliation Reconciliation marker.
+     * @param configMap ConfigMap with the metrics exporter configuration.
+     *
+     * @return  String with JSON formatted metrics configuration or null if metrics are not enabled
+     */
+    public String metricsJson(Reconciliation reconciliation, ConfigMap configMap) {
+        if (isEnabled)  {
+            if (configMap == null) {
+                LOGGER.warnCr(reconciliation, "ConfigMap {} does not exist.", configMapName);
+                throw new InvalidConfigurationException("ConfigMap " + configMapName + " does not exist");
+            } else {
+                String data = configMap.getData().get(configMapKey);
+
+                if (data == null) {
+                    LOGGER.warnCr(reconciliation, "ConfigMap {} does not contain specified key {}.", configMapName, configMapKey);
+                    throw new InvalidConfigurationException("ConfigMap " + configMapName + " does not contain specified key " + configMapKey);
+                } else {
+                    if (data.isEmpty()) {
+                        return "{}";
+                    }
+
+                    try {
+                        ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+                        Object yaml = yamlReader.readValue(data, Object.class);
+                        ObjectMapper jsonWriter = new ObjectMapper();
+
+                        return jsonWriter.writeValueAsString(yaml);
+                    } catch (JsonProcessingException e) {
+                        throw new InvalidConfigurationException("Failed to parse metrics configuration", e);
+                    }
+                }
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Validates user configuration.
+     *
+     * @param config User config to be validated.
+     */
+    /* test */ static void validateJmxExporterMetricsConfig(JmxPrometheusExporterMetrics config) {
+        List<String> errors = new ArrayList<>();
+
+        if (config.getValueFrom() != null
+                && config.getValueFrom().getConfigMapKeyRef() != null) {
+            // The Config Map reference exists
+            if (config.getValueFrom().getConfigMapKeyRef().getName() == null
+                    || config.getValueFrom().getConfigMapKeyRef().getName().isEmpty()) {
+                errors.add("Name of the Config Map with metrics configuration is missing");
+            }
+
+            if (config.getValueFrom().getConfigMapKeyRef().getKey() == null
+                    || config.getValueFrom().getConfigMapKeyRef().getKey().isEmpty()) {
+                errors.add("The key under which the metrics configuration is stored in the ConfigMap is missing");
+            }
+        } else {
+            // The Config Map reference is missing
+            errors.add("Config Map reference is missing");
+        }
+
+        if (!errors.isEmpty())  {
+            throw new InvalidResourceException("Metrics configuration is invalid: " + errors);
+        }
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/MetricsModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/MetricsModel.java
@@ -4,157 +4,22 @@
  */
 package io.strimzi.operator.cluster.model.metrics;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.strimzi.api.kafka.model.common.HasConfigurableMetrics;
-import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetrics;
-import io.strimzi.operator.common.InvalidConfigurationException;
-import io.strimzi.operator.common.Reconciliation;
-import io.strimzi.operator.common.ReconciliationLogger;
-import io.strimzi.operator.common.model.InvalidResourceException;
-
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- * Represents a model for components with configurable metrics
+ * The metrics model.
  */
-public class MetricsModel {
-    private static final ReconciliationLogger LOGGER = ReconciliationLogger.create(MetricsModel.class.getName());
+public interface MetricsModel {
+    /**
+     * Metrics endpoint port name.
+     */
+    String METRICS_PORT_NAME = "tcp-prometheus";
 
     /**
-     * Name of the Prometheus metrics port
+     * Metrics endpoint port number.
      */
-    public static final String METRICS_PORT_NAME = "tcp-prometheus";
+    int METRICS_PORT = 9404;
 
     /**
-     * Number of the Prometheus metrics port
+     * @return Whether the endpoint is enabled.
      */
-    public static final int METRICS_PORT = 9404;
-
-    /**
-     * Key under which the metrics configuration is stored in the ConfigMap
-     */
-    public static final String CONFIG_MAP_KEY = "metrics-config.json";
-
-    private final boolean isEnabled;
-    private final String configMapName;
-    private final String configMapKey;
-
-    /**
-     * Constructs the Metrics Model for managing configurable metrics to Strimzi
-     *
-     * @param specSection       Custom resource section configuring metrics
-     */
-    public MetricsModel(HasConfigurableMetrics specSection) {
-        if (specSection.getMetricsConfig() != null) {
-            if (specSection.getMetricsConfig() instanceof JmxPrometheusExporterMetrics jmxMetrics) {
-                validateJmxPrometheusExporterMetricsConfiguration(jmxMetrics);
-
-                this.isEnabled = true;
-                this.configMapName = jmxMetrics.getValueFrom().getConfigMapKeyRef().getName();
-                this.configMapKey = jmxMetrics.getValueFrom().getConfigMapKeyRef().getKey();
-            } else {
-                throw new InvalidResourceException("Unsupported metrics type " + specSection.getMetricsConfig().getType());
-            }
-        } else {
-            this.isEnabled = false;
-            this.configMapName = null;
-            this.configMapKey = null;
-        }
-    }
-
-    /**
-     * @return  True if metrics are enabled. False otherwise.
-     */
-    public boolean isEnabled() {
-        return isEnabled;
-    }
-
-    /**
-     * @return  The name of the Config Map with the metrics configuration
-     */
-    public String getConfigMapName() {
-        return configMapName;
-    }
-
-    /**
-     * @return  The key under which the metrics configuration is stored in the Config Map
-     */
-    public String getConfigMapKey() {
-        return configMapKey;
-    }
-
-    /**
-     * Generates Prometheus metrics configuration based on the JMXExporter configuration from the user-provided
-     * ConfigMap. When metrics are not enabled, returns null.
-     *
-     * @param reconciliation    Reconciliation marker
-     * @param configMap         ConfigMap with the metrics exporter configuration
-     *
-     * @return  String with JSON formatted metrics configuration or null if metrics are not enabled
-     */
-    public String metricsJson(Reconciliation reconciliation, ConfigMap configMap) {
-        if (isEnabled)  {
-            if (configMap == null) {
-                LOGGER.warnCr(reconciliation, "ConfigMap {} does not exist.", configMapName);
-                throw new InvalidConfigurationException("ConfigMap " + configMapName + " does not exist");
-            } else {
-                String data = configMap.getData().get(configMapKey);
-
-                if (data == null) {
-                    LOGGER.warnCr(reconciliation, "ConfigMap {} does not contain specified key {}.", configMapName, configMapKey);
-                    throw new InvalidConfigurationException("ConfigMap " + configMapName + " does not contain specified key " + configMapKey);
-                } else {
-                    if (data.isEmpty()) {
-                        return "{}";
-                    }
-
-                    try {
-                        ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
-                        Object yaml = yamlReader.readValue(data, Object.class);
-                        ObjectMapper jsonWriter = new ObjectMapper();
-
-                        return jsonWriter.writeValueAsString(yaml);
-                    } catch (JsonProcessingException e) {
-                        throw new InvalidConfigurationException("Failed to parse metrics configuration", e);
-                    }
-                }
-            }
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Validates the JMX Prometheus Exporter Metrics configuration
-     *
-     * @param jmxMetrics    JMX Prometheus Exporter Metrics configuration which should be validated
-     */
-    /* test */ static void validateJmxPrometheusExporterMetricsConfiguration(JmxPrometheusExporterMetrics jmxMetrics)   {
-        List<String> errors = new ArrayList<>();
-
-        if (jmxMetrics.getValueFrom() != null
-                && jmxMetrics.getValueFrom().getConfigMapKeyRef() != null)   {
-            // The Config Map reference exists
-            if (jmxMetrics.getValueFrom().getConfigMapKeyRef().getName() == null
-                    || jmxMetrics.getValueFrom().getConfigMapKeyRef().getName().isEmpty())  {
-                errors.add("Name of the Config Map with metrics configuration is missing");
-            }
-
-            if (jmxMetrics.getValueFrom().getConfigMapKeyRef().getKey() == null
-                    || jmxMetrics.getValueFrom().getConfigMapKeyRef().getKey().isEmpty())  {
-                errors.add("The key under which the metrics configuration is stored in the ConfigMap is missing");
-            }
-        } else {
-            // The Config Map reference is missing
-            errors.add("Config Map reference is missing");
-        }
-
-        if (!errors.isEmpty())  {
-            throw new InvalidResourceException("Metrics configuration is invalid: " + errors);
-        }
-    }
+    boolean isEnabled();
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModel.java
@@ -15,39 +15,29 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
- * Represents a model for components with configurable metrics using Strimzi Reporter
+ * Model for the Strimzi Metrics Reporter Kafka plugin.
  */
-public class StrimziMetricsReporterModel {
+public class StrimziMetricsReporterModel implements MetricsModel {
     /**
-     * Fully Qualified Class Name of the Strimzi Kafka Prometheus Metrics Reporter.
+     * Fully qualified class name of the Strimzi Metrics Reporter.
      */
     public static final String KAFKA_PROMETHEUS_METRICS_REPORTER = "io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter";
 
-    /**
-     * Name of the Strimzi metrics port
-     */
-    public static final String METRICS_PORT_NAME = "tcp-prometheus";
-
-    /**
-     * Number of the Strimzi metrics port
-     */
-    public static final int METRICS_PORT = 9404;
     private final boolean isEnabled;
     private final List<String> allowList;
 
     /**
-     * Constructs the StrimziMetricsReporterModel for managing configurable metrics with Strimzi Reporter
+     * Constructs the Metrics Model for managing configurable metrics to Strimzi.
      *
-     * @param spec StrimziReporterMetrics object containing the metrics configuration
+     * @param spec Custom resource section configuring metrics.
      */
     public StrimziMetricsReporterModel(HasConfigurableMetrics spec) {
         if (spec.getMetricsConfig() != null) {
             if (spec.getMetricsConfig() instanceof StrimziMetricsReporter config) {
                 validate(config);
                 this.isEnabled = true;
-                this.allowList = config.getValues() != null &&
-                        config.getValues().getAllowList() != null
-                        ? config.getValues().getAllowList() : null;
+                this.allowList = config.getValues() != null && config.getValues().getAllowList() != null 
+                    ? config.getValues().getAllowList() : null;
             } else {
                 throw new InvalidResourceException("Unsupported metrics type " + spec.getMetricsConfig().getType());
             }
@@ -57,43 +47,42 @@ public class StrimziMetricsReporterModel {
         }
     }
 
-    /**
-     * @return True if metrics are enabled. False otherwise.
-     */
+    @Override
     public boolean isEnabled() {
         return isEnabled;
     }
 
     /**
-     * Validates the Strimzi Metrics Reporter configuration
+     * @return Comma separated list of allow regex expressions.
+     */
+    public Optional<String> getAllowList() {
+        return allowList != null ? Optional.of(String.join(",", allowList)) : Optional.empty();
+    }
+
+    /**
+     * Validates user configuration.
      *
-     * @param config StrimziReporterMetrics configuration to validate
+     * @param config Config to be validated.
      */
     /* test */ static void validate(StrimziMetricsReporter config) {
         List<String> errors = new ArrayList<>();
+
         if (config.getValues() != null && config.getValues().getAllowList() != null) {
             if (config.getValues().getAllowList().isEmpty()) {
                 errors.add("Allowlist should contain at least one element");
             }
+            
             for (String regex : config.getValues().getAllowList()) {
                 try {
                     Pattern.compile(regex);
-                } catch (PatternSyntaxException e) {
-                    errors.add(String.format("Invalid regex: %s, %s", regex, e.getDescription()));
+                } catch (PatternSyntaxException pse) {
+                    errors.add(String.format("Invalid regex: %s, %s", regex, pse.getDescription()));
                 }
             }
         }
+
         if (!errors.isEmpty()) {
             throw new InvalidResourceException("Metrics configuration is invalid: " + errors);
         }
-    }
-
-    /**
-     * Returns the allowlist as a comma-separated string wrapped in an Optional.
-     *
-     * @return an Optional containing the comma-separated allowlist if it is not null, otherwise an empty Optional
-     */
-    public Optional<String> getAllowList() {
-        return allowList != null ? Optional.of(String.join(",", allowList)) : Optional.empty();
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtils.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.strimzi.api.kafka.model.common.ExternalLogging;
 import io.strimzi.operator.cluster.model.MetricsAndLogging;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
 import io.strimzi.operator.common.Reconciliation;
@@ -42,8 +43,9 @@ public class MetricsAndLoggingUtils {
     }
 
     private static Future<ConfigMap> metricsConfigMap(Reconciliation reconciliation, ConfigMapOperator configMapOperations, MetricsModel metrics) {
-        if (metrics != null && metrics.isEnabled()) {
-            return configMapOperations.getAsync(reconciliation.namespace(), metrics.getConfigMapName());
+        // this is only for JMX Prometheus Exporter, because the Strimzi Metrics Reporter configuration is in the Kafka configuration file
+        if (metrics != null && metrics.isEnabled() && metrics instanceof JmxPrometheusExporterModel) {
+            return configMapOperations.getAsync(reconciliation.namespace(), ((JmxPrometheusExporterModel) metrics).getConfigMapName());
         } else {
             return Future.succeededFuture(null);
         }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ConfigMapUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/ConfigMapUtilsTest.java
@@ -17,6 +17,7 @@ import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.logging.SupportsLogging;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.cluster.model.metrics.SupportsMetrics;
 import io.strimzi.operator.common.Reconciliation;
@@ -85,7 +86,7 @@ public class ConfigMapUtilsTest {
         Map<String, String> data = ConfigMapUtils.generateMetricsAndLogConfigMapData(Reconciliation.DUMMY_RECONCILIATION, new ModelWithMetricsAndLogging(kafka), new MetricsAndLogging(new ConfigMapBuilder().withNewMetadata().withName("metrics-cm").endMetadata().withData(Map.of("metrics.yaml", "")).build(), new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of("log4j.properties", "")).build()));
 
         assertThat(data.size(), is(2));
-        assertThat(data.get(MetricsModel.CONFIG_MAP_KEY), is(notNullValue()));
+        assertThat(data.get(JmxPrometheusExporterModel.CONFIG_MAP_KEY), is(notNullValue()));
         assertThat(data.get(LoggingModel.LOG4J1_CONFIG_MAP_KEY), is(notNullValue()));
     }
 
@@ -109,7 +110,7 @@ public class ConfigMapUtilsTest {
 
         @Override
         public MetricsModel metrics() {
-            return new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
+            return new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
         }
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -1115,7 +1115,7 @@ public class CruiseControlTest {
         InvalidResourceException ex = assertThrows(InvalidResourceException.class, 
             () -> createCruiseControl(kafka, NODES, STORAGE, Map.of()));
 
-        assertThat(ex.getMessage(), is("The Strimzi Metrics Reporter is not supported for Cruise Control"));
+        assertThat(ex.getMessage(), is("The Strimzi Metrics Reporter is not supported with Cruise Control"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -79,7 +79,7 @@ import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
-import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
 import io.strimzi.operator.common.Annotations;
@@ -299,7 +299,7 @@ public class KafkaClusterTest {
                 TestUtils.checkOwnerReference(cm, POOL_BROKERS);
             }
 
-            assertThat(cm.getData().get(MetricsModel.CONFIG_MAP_KEY), is("{\"animal\":\"wombat\"}"));
+            assertThat(cm.getData().get(JmxPrometheusExporterModel.CONFIG_MAP_KEY), is("{\"animal\":\"wombat\"}"));
         }
     }
 
@@ -2039,14 +2039,13 @@ public class KafkaClusterTest {
         KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaAssembly, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, null, SHARED_ENV_PROVIDER);
 
         assertThat(kc.metrics().isEnabled(), is(true));
-        assertThat(kc.metrics().getConfigMapName(), is("my-metrics-configuration"));
-        assertThat(kc.metrics().getConfigMapKey(), is("config.yaml"));
+        assertThat(((JmxPrometheusExporterModel) kc.metrics()).getConfigMapName(), is("my-metrics-configuration"));
+        assertThat(((JmxPrometheusExporterModel) kc.metrics()).getConfigMapKey(), is("config.yaml"));
     }
 
     @ParallelTest
     public void testMetricsParsingNoMetrics() {
         assertThat(KC.metrics(), is(nullValue()));
-        assertThat(KC.strimziMetricsReporter(), is(nullValue()));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectClusterTest.java
@@ -74,6 +74,7 @@ import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -170,7 +171,7 @@ public class KafkaConnectClusterTest {
     }
 
     private void checkMetricsConfigMap(ConfigMap metricsCm) {
-        assertThat(metricsCm.getData().get(MetricsModel.CONFIG_MAP_KEY), is(metricsCmJson));
+        assertThat(metricsCm.getData().get(JmxPrometheusExporterModel.CONFIG_MAP_KEY), is(metricsCmJson));
     }
 
     private Map<String, String> expectedLabels(String name)    {
@@ -2094,8 +2095,8 @@ public class KafkaConnectClusterTest {
         KafkaConnectCluster kc = KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaConnect, VERSIONS, SHARED_ENV_PROVIDER);
 
         assertThat(kc.metrics().isEnabled(), is(true));
-        assertThat(kc.metrics().getConfigMapName(), is("my-metrics-configuration"));
-        assertThat(kc.metrics().getConfigMapKey(), is("config.yaml"));
+        assertThat(((JmxPrometheusExporterModel) kc.metrics()).getConfigMapName(), is("my-metrics-configuration"));
+        assertThat(((JmxPrometheusExporterModel) kc.metrics()).getConfigMapKey(), is("config.yaml"));
     }
 
     @ParallelTest
@@ -2118,7 +2119,7 @@ public class KafkaConnectClusterTest {
         InvalidResourceException ex = assertThrows(InvalidResourceException.class,
             () -> KafkaConnectCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resourceWithMetrics, VERSIONS, SHARED_ENV_PROVIDER));
 
-        assertThat(ex.getMessage(), is("The Strimzi Metrics Reporter is not supported for this component"));
+        assertThat(ex.getMessage(), is("The Strimzi Metrics Reporter is not supported with this component"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ClusterTest.java
@@ -69,6 +69,7 @@ import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.ResourceUtils;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -172,7 +173,7 @@ public class KafkaMirrorMaker2ClusterTest {
     }
 
     private void checkMetricsConfigMap(ConfigMap metricsCm) {
-        assertThat(metricsCm.getData().get(MetricsModel.CONFIG_MAP_KEY), is(metricsCmJson));
+        assertThat(metricsCm.getData().get(JmxPrometheusExporterModel.CONFIG_MAP_KEY), is(metricsCmJson));
     }
 
     private Map<String, String> expectedLabels(String name)    {
@@ -2190,8 +2191,8 @@ public class KafkaMirrorMaker2ClusterTest {
         KafkaMirrorMaker2Cluster kmm = KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafkaMirrorMaker2, VERSIONS, SHARED_ENV_PROVIDER);
 
         assertThat(kmm.metrics().isEnabled(), is(true));
-        assertThat(kmm.metrics().getConfigMapName(), is("my-metrics-configuration"));
-        assertThat(kmm.metrics().getConfigMapKey(), is("config.yaml"));
+        assertThat(((JmxPrometheusExporterModel) kmm.metrics()).getConfigMapName(), is("my-metrics-configuration"));
+        assertThat(((JmxPrometheusExporterModel) kmm.metrics()).getConfigMapKey(), is("config.yaml"));
     }
 
     @ParallelTest
@@ -2254,7 +2255,7 @@ public class KafkaMirrorMaker2ClusterTest {
         InvalidResourceException ex = assertThrows(InvalidResourceException.class,
             () -> KafkaMirrorMaker2Cluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, resourceWithMetrics, VERSIONS, SHARED_ENV_PROVIDER));
 
-        assertThat(ex.getMessage(), is("The Strimzi Metrics Reporter is not supported for this component"));
+        assertThat(ex.getMessage(), is("The Strimzi Metrics Reporter is not supported with this component"));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/JmxExporterMetricsModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/JmxExporterMetricsModelTest.java
@@ -23,10 +23,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class MetricsModelTest {
+public class JmxExporterMetricsModelTest {
     @Test
     public void testDisabled()   {
-        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().build());
+        JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().build());
 
         assertThat(metrics.isEnabled(), is(false));
         assertThat(metrics.getConfigMapName(), is(nullValue()));
@@ -41,7 +41,7 @@ public class MetricsModelTest {
                 .endValueFrom()
                 .build();
 
-        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(metricsConfig).build());
+        JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().withMetricsConfig(metricsConfig).build());
 
         assertThat(metrics.isEnabled(), is(true));
         assertThat(metrics.getConfigMapName(), is("my-name"));
@@ -58,7 +58,7 @@ public class MetricsModelTest {
                 .endValueFrom()
                 .build();
 
-        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(metricsConfig).build());
+        JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().withMetricsConfig(metricsConfig).build());
 
         InvalidConfigurationException ex = assertThrows(InvalidConfigurationException.class, () -> metrics.metricsJson(Reconciliation.DUMMY_RECONCILIATION, null));
         assertThat(ex.getMessage(), is("ConfigMap my-name does not exist"));
@@ -72,18 +72,18 @@ public class MetricsModelTest {
 
     @Test
     public void testPrometheusJmxMetricsValidation() {
-        assertDoesNotThrow(() -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("my-key", "my-name", false)).endValueFrom().build()));
+        assertDoesNotThrow(() -> JmxPrometheusExporterModel.validateJmxExporterMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("my-key", "my-name", false)).endValueFrom().build()));
 
-        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector()).endValueFrom().build()));
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> JmxPrometheusExporterModel.validateJmxExporterMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector()).endValueFrom().build()));
         assertThat(ex.getMessage(), is("Metrics configuration is invalid: [Name of the Config Map with metrics configuration is missing, The key under which the metrics configuration is stored in the ConfigMap is missing]"));
 
-        ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector(null, "my-name", false)).endValueFrom().build()));
+        ex = assertThrows(InvalidResourceException.class, () -> JmxPrometheusExporterModel.validateJmxExporterMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector(null, "my-name", false)).endValueFrom().build()));
         assertThat(ex.getMessage(), is("Metrics configuration is invalid: [The key under which the metrics configuration is stored in the ConfigMap is missing]"));
 
-        ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().endValueFrom().build()));
+        ex = assertThrows(InvalidResourceException.class, () -> JmxPrometheusExporterModel.validateJmxExporterMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().endValueFrom().build()));
         assertThat(ex.getMessage(), is("Metrics configuration is invalid: [Config Map reference is missing]"));
 
-        ex = assertThrows(InvalidResourceException.class, () -> MetricsModel.validateJmxPrometheusExporterMetricsConfiguration(new JmxPrometheusExporterMetricsBuilder().build()));
+        ex = assertThrows(InvalidResourceException.class, () -> JmxPrometheusExporterModel.validateJmxExporterMetricsConfig(new JmxPrometheusExporterMetricsBuilder().build()));
         assertThat(ex.getMessage(), is("Metrics configuration is invalid: [Config Map reference is missing]"));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterModelTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StrimziMetricsReporterModelTest {
-
     @Test
     public void testDisabled() {
         StrimziMetricsReporterModel metrics = new StrimziMetricsReporterModel(new KafkaClusterSpecBuilder().build());
@@ -71,5 +70,4 @@ public class StrimziMetricsReporterModelTest {
         );
         assertThat(ise1.getMessage(), is("Metrics configuration is invalid: [Invalid regex: kafka_log.***, Dangling meta character '*', Invalid regex: [a+, Unclosed character class]"));
     }
-
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaBridgeAssemblyOperatorTest.java
@@ -27,7 +27,7 @@ import io.strimzi.operator.cluster.model.KafkaBridgeCluster;
 import io.strimzi.operator.cluster.model.KafkaVersion;
 import io.strimzi.operator.cluster.model.MockSharedEnvironmentProvider;
 import io.strimzi.operator.cluster.model.SharedEnvironmentProvider;
-import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ClusterRoleBindingOperator;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
@@ -317,7 +317,7 @@ public class KafkaBridgeAssemblyOperatorTest {
                     .withName(KafkaBridgeResources.metricsAndLogConfigMapName(kbName))
                     .withNamespace(kbNamespace)
                 .endMetadata()
-                .withData(Collections.singletonMap(MetricsModel.CONFIG_MAP_KEY, METRICS_CONFIG))
+                .withData(Collections.singletonMap(JmxPrometheusExporterModel.CONFIG_MAP_KEY, METRICS_CONFIG))
                 .build();
         when(mockCmOps.get(kbNamespace, KafkaBridgeResources.metricsAndLogConfigMapName(kbName))).thenReturn(metricsCm);
 

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtilsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/MetricsAndLoggingUtilsTest.java
@@ -11,7 +11,7 @@ import io.strimzi.api.kafka.model.common.metrics.JmxPrometheusExporterMetricsBui
 import io.strimzi.api.kafka.model.connect.KafkaConnectSpec;
 import io.strimzi.api.kafka.model.connect.KafkaConnectSpecBuilder;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
-import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
 import io.strimzi.operator.cluster.operator.resource.kubernetes.ConfigMapOperator;
 import io.strimzi.operator.common.Reconciliation;
 import io.vertx.core.Future;
@@ -40,26 +40,26 @@ public class MetricsAndLoggingUtilsTest {
     @Test
     public void testNoMetricsAndNoExternalLogging(VertxTestContext context)   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpec(), "KafkaConnectCluster", false, true);
-        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().build());
+        JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().build());
 
         ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
 
         Checkpoint async = context.checkpoint();
         MetricsAndLoggingUtils.metricsAndLogging(Reconciliation.DUMMY_RECONCILIATION, mockCmOps, logging, metrics)
-                .onComplete(context.succeeding(v -> context.verify(() -> {
-                    assertThat(v.loggingCm(), is(nullValue()));
-                    assertThat(v.metricsCm(), is(nullValue()));
+            .onComplete(context.succeeding(v -> context.verify(() -> {
+                assertThat(v.loggingCm(), is(nullValue()));
+                assertThat(v.metricsCm(), is(nullValue()));
 
-                    verify(mockCmOps, never()).getAsync(any(), any());
+                verify(mockCmOps, never()).getAsync(any(), any());
 
-                    async.flag();
-                })));
+                async.flag();
+            })));
     }
 
     @Test
     public void testMetricsAndExternalLogging(VertxTestContext context)   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpecBuilder().withLogging(new ExternalLoggingBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("log4j.properties", "logging-cm", false)).endValueFrom().build()).build(), "KafkaConnectCluster", false, true);
-        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
+        JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
 
         ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
         when(mockCmOps.getAsync(any(), eq("logging-cm"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of()).build()));
@@ -83,7 +83,7 @@ public class MetricsAndLoggingUtilsTest {
     @Test
     public void testNoMetricsAndExternalLogging(VertxTestContext context)   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpecBuilder().withLogging(new ExternalLoggingBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("log4j.properties", "logging-cm", false)).endValueFrom().build()).build(), "KafkaConnectCluster", false, true);
-        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().build());
+        JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().build());
 
         ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
         when(mockCmOps.getAsync(any(), eq("logging-cm"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withNewMetadata().withName("logging-cm").endMetadata().withData(Map.of()).build()));
@@ -105,7 +105,7 @@ public class MetricsAndLoggingUtilsTest {
     @Test
     public void testMetricsAndNoExternalLogging(VertxTestContext context)   {
         LoggingModel logging = new LoggingModel(new KafkaConnectSpec(), "KafkaConnectCluster", false, true);
-        MetricsModel metrics = new MetricsModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
+        JmxPrometheusExporterModel metrics = new JmxPrometheusExporterModel(new KafkaConnectSpecBuilder().withMetricsConfig(new JmxPrometheusExporterMetricsBuilder().withNewValueFrom().withConfigMapKeyRef(new ConfigMapKeySelector("metrics.yaml", "metrics-cm", false)).endValueFrom().build()).build());
 
         ConfigMapOperator mockCmOps = mock(ConfigMapOperator.class);
         when(mockCmOps.getAsync(any(), eq("metrics-cm"))).thenReturn(Future.succeededFuture(new ConfigMapBuilder().withNewMetadata().withName("metrics-cm").endMetadata().withData(Map.of()).build()));


### PR DESCRIPTION
DO NOT MERGE, JUST COPY CHANGES MANUALLY, BUILD, TEST AND PUSH TO THE OPEN PR.

All changes are just refactorings related to this comment:

> We have MetricsModel for a reason. We should try to unify both metrics types into a single class (e.g. have MetricsModel as abstract class or interface and then two implementations for the different metric types).

