### PR TITLE
Add Support for the Strimzi Metrics Reporter to Kafka Connect and MirrorMaker2 

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -32,6 +32,8 @@
 * [Cloudera](https://www.cloudera.com/products/stream-processing.html)
 * [SURF](https://surf.nl)
    * Use Strimzi to create a (streaming) telemetry platform and EDA for Network Orchestration.
+* [AppsFlyer](https://www.appsflyer.com/)
+  * Running dozens of high-throughput clusters, handling tens of millions of messages per second, relying on the local ephemeral storage.
 
 Are you currently using Strimzi in production?
 Please let us know by adding your company name and, if you want, a description of your use case to this document!

--- a/documentation/modules/configuring/ref-storage-tiered.adoc
+++ b/documentation/modules/configuring/ref-storage-tiered.adoc
@@ -1,12 +1,12 @@
 [id='ref-tiered-storage-{context}']
-= Tiered storage (early access)
+= Tiered storage
 
 [role="_abstract"]
 Tiered storage introduces a flexible approach to managing Kafka data whereby log segments are moved to a separate storage system. 
 For example, you can combine the use of block storage on brokers for frequently accessed data and offload older or less frequently accessed data from the block storage to more cost-effective, scalable remote storage solutions, such as Amazon S3, without compromising data accessibility and durability.
 
-WARNING: Tiered storage is an early access Kafka feature, which is also available in Strimzi. 
-Due to its https://kafka.apache.org/documentation/#tiered_storage_limitation[current limitations^], it is not recommended for production environments. 
+NOTE: Tiered storage is a production-ready feature in Kafka since version 3.9.0, and it is also supported in Strimzi.
+Before introducing tiered storage to your environment, review the https://kafka.apache.org/documentation/#tiered_storage_limitation[known limitations^] of this feature.
 
 Tiered storage requires an implementation of Kafka's `RemoteStorageManager` interface to handle communication between Kafka and the remote storage system, which is enabled through configuration of the `Kafka` resource.
 Strimzi uses Kafka's https://github.com/apache/kafka/blob/trunk/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java[`TopicBasedRemoteLogMetadataManager`^] for Remote Log Metadata Management (RLMM) when custom tiered storage is enabled.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature


### Description
This patch adds support for the Strimzi Metrics Reporter to Kafka Connect and MirrorMaker2 as described by the following proposal:

https://github.com/strimzi/proposals/blob/main/064-prometheus-metrics-reporter.md

Related to #10753

We won’t initially support the CruiseControl component. To make it work, CC should be changed to expose metrics through its HTTP endpoint.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md