### PR TITLE
KC and MM2 integration with Metrics Reporter

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/AbstractKafkaConnectSpec.java
@@ -23,7 +23,6 @@ import io.strimzi.api.kafka.model.common.jmx.HasJmxOptions;
 import io.strimzi.api.kafka.model.common.jmx.KafkaJmxOptions;
 import io.strimzi.api.kafka.model.common.metrics.MetricsConfig;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
-import io.strimzi.crdgenerator.annotations.CelValidation;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.sundr.builder.annotations.Buildable;
@@ -156,18 +155,8 @@ public abstract class AbstractKafkaConnectSpec extends Spec implements HasConfig
         this.jmxOptions = jmxOptions;
     }
 
-    @Description("Metrics configuration. Only `jmxPrometheusExporter` can be configured, as this component does not yet support `strimziMetricsReporter`.")
+    @Description("Metrics configuration.")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @CelValidation(rules = {
-        @CelValidation.CelValidationRule(
-                rule = "self.type != 'jmxPrometheusExporter' || has(self.valueFrom)",
-                message = "valueFrom property is required"
-            ),
-        @CelValidation.CelValidationRule(
-                rule = "self.type != 'strimziMetricsReporter'",
-                message = "value type not supported"
-            )
-    })
     @Override
     public MetricsConfig getMetricsConfig() {
         return metricsConfig;

--- a/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/connect/KafkaConnectSpec.java
@@ -33,7 +33,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true)
 public class KafkaConnectSpec extends AbstractKafkaConnectSpec {
-    public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes";
+    public static final String FORBIDDEN_PREFIXES = "ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter.";
     public static final String FORBIDDEN_PREFIX_EXCEPTIONS = "ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols";
 
     private Map<String, Object> config = new HashMap<>(0);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -31,6 +31,7 @@ import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.kafka.oauth.server.plain.ServerPlainConfig;
 import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsReporter;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterConfig;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
@@ -39,11 +40,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -63,8 +62,6 @@ public class KafkaBrokerConfigurationBuilder {
     // Names of environment variables expanded through config providers inside the Kafka node
     private final static String PLACEHOLDER_CERT_STORE_PASSWORD_CONFIG_PROVIDER_ENV_VAR = "${strimzienv:CERTS_STORE_PASSWORD}";
     private final static String PLACEHOLDER_OAUTH_CLIENT_SECRET_TEMPLATE_CONFIG_PROVIDER_ENV_VAR = "${strimzienv:STRIMZI_%s_OAUTH_CLIENT_SECRET}";
-
-    private final static String KAFKA_JMX_REPORTER_CLASS = "org.apache.kafka.common.metrics.JmxReporter";
 
     private final StringWriter stringWriter = new StringWriter();
     private final PrintWriter writer = new PrintWriter(stringWriter);
@@ -150,9 +147,9 @@ public class KafkaBrokerConfigurationBuilder {
     public KafkaBrokerConfigurationBuilder withStrimziMetricsReporter(MetricsModel model)   {
         if (model instanceof StrimziMetricsReporterModel reporterModel) {
             printSectionHeader("Strimzi Metrics Reporter configuration");
-            writer.println("prometheus.metrics.reporter.listener.enable=true");
-            writer.println("prometheus.metrics.reporter.listener=http://:" + StrimziMetricsReporterModel.METRICS_PORT);
-            writer.println("prometheus.metrics.reporter.allowlist=" + reporterModel.getAllowList());
+            writer.println(StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true");
+            writer.println(StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT);
+            writer.println(StrimziMetricsReporterConfig.ALLOW_LIST + "=" + reporterModel.getAllowList());
             writer.println();
         }
         return this;
@@ -811,8 +808,8 @@ public class KafkaBrokerConfigurationBuilder {
      *
      * @param userConfig                The User configuration - Kafka broker configuration options specified by the user in the Kafka custom resource
      * @param injectCcMetricsReporter   Inject the Cruise Control Metrics Reporter into the configuration
+     * @param injectKafkaJmxReporter         Flag to indicate if metrics are enabled. If they are we inject the JmxReporter into the configuration
      * @param injectStrimziMetricsReporter   Inject the Strimzi Metrics Reporter into the configuration
-     * @param injectKafkaJmxReporter          Flag to indicate if metrics are enabled. If they are we inject the JmxReporter into the configuration
      *
      * @return Returns the builder instance
      */
@@ -835,7 +832,7 @@ public class KafkaBrokerConfigurationBuilder {
 
         // print user config with Strimzi injections
         if (!userConfig.getConfiguration().isEmpty()) {
-            printSectionHeader("User provided configuration");
+            printSectionHeader("User provided configuration with Strimzi injections");
             writer.println(userConfig.getConfiguration());
             writer.println();
         }
@@ -850,16 +847,17 @@ public class KafkaBrokerConfigurationBuilder {
      * @param injectCcMetricsReporter Flag indicating whether to inject the Cruise Control Metrics Reporter.
      * @param injectKafkaJmxReporter  Inject the JMX Reporter into the configuration
      * @param injectStrimziMetricsReporter Flag indicating whether to inject the Strimzi Metrics Reporter.
+     *
      */
     private void maybeAddMetricReporters(KafkaConfiguration userConfig, boolean injectCcMetricsReporter, boolean injectKafkaJmxReporter, boolean injectStrimziMetricsReporter) {
         if (injectCcMetricsReporter) {
-            createOrAddListConfig(userConfig, "metric.reporters", CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER);
+            ModelUtils.createOrAddListConfig(userConfig, "metric.reporters", CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER);
         }
         if (injectKafkaJmxReporter) {
-            createOrAddListConfig(userConfig, "metric.reporters", "org.apache.kafka.common.metrics.JmxReporter");
+            ModelUtils.createOrAddListConfig(userConfig, "metric.reporters", "org.apache.kafka.common.metrics.JmxReporter");
         }
         if (injectStrimziMetricsReporter) {
-            createOrAddListConfig(userConfig, "metric.reporters", "io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter");
+            ModelUtils.createOrAddListConfig(userConfig, "metric.reporters", StrimziMetricsReporterConfig.KAFKA_CLASS);
         }
     }
 
@@ -871,7 +869,7 @@ public class KafkaBrokerConfigurationBuilder {
      */
     private void maybeAddYammerMetricsReporters(KafkaConfiguration userConfig, boolean injectStrimziMetricsReporter) {
         if (injectStrimziMetricsReporter) {
-            createOrAddListConfig(userConfig, "kafka.metrics.reporters", "io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter");
+            ModelUtils.createOrAddListConfig(userConfig, "kafka.metrics.reporters", StrimziMetricsReporterConfig.YAMMER_CLASS);
         }
     }
 
@@ -1014,45 +1012,6 @@ public class KafkaBrokerConfigurationBuilder {
         }
 
         writer.println(String.format("client.quota.callback.static.excluded.principal.name.list=%s", String.join(";", excludedPrincipals)));
-    }
-
-    /**
-     * Append list configuration values or create a new list configuration if missing.
-     * A list configuration can contain a comma separated list of values.
-     * Duplicated values are removed.
-     *
-     * @param kafkaConfig Kafka configuration.
-     * @param key List configuration key.
-     * @param values List configuration values.
-     */
-    static void createOrAddListConfig(AbstractConfiguration kafkaConfig, String key, String values) {
-        if (kafkaConfig == null) {
-            throw new IllegalArgumentException("Configuration is required");
-        }
-        if (key == null || key.isBlank()) {
-            throw new IllegalArgumentException("Configuration key is required");
-        }
-        if (values == null || values.isBlank()) {
-            throw new IllegalArgumentException("Configuration values are required");
-        }
-
-        String existingConfig = kafkaConfig.getConfigOption(key);
-        // using an ordered set to preserve ordering of the existing kafkaConfig as values could potentially be user-provided.
-        Set<String> existingSet = existingConfig == null ? new LinkedHashSet<>() :
-                Arrays.stream(existingConfig.split(","))
-                        .map(String::trim)
-                        .filter(s -> !s.isEmpty())
-                        .collect(Collectors.toCollection(LinkedHashSet::new));
-        Set<String> newValues = Arrays.stream(values.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        // add only new values
-        boolean updated = existingSet.addAll(newValues);
-        if (updated) {
-            String updatedConfig = String.join(",", existingSet);
-            kafkaConfig.setConfigOption(key, updatedConfig);
-        }
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectConfiguration.java
@@ -34,6 +34,18 @@ public class KafkaConnectConfiguration extends AbstractConfiguration {
     }
 
     /**
+     * Copy constructor which creates new instance of the Kafka Connect configuration from existing configuration.
+     * It is useful when you need to modify an instance of the configuration without permanently changing the original.
+     *
+     * @param configuration User provided Kafka Connect configuration
+     *
+     */
+    public KafkaConnectConfiguration(KafkaConnectConfiguration configuration) {
+        super(configuration);
+    }
+
+
+    /**
      * Constructor used to instantiate this class from JsonObject. Should be used to create configuration from
      * ConfigMap / CRD.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Configuration.java
@@ -35,6 +35,17 @@ public class KafkaMirrorMaker2Configuration extends AbstractConfiguration {
     }
 
     /**
+     * Copy constructor which creates new instance of the Mirror Maker 2 configuration from existing configuration.
+     * It is useful when you need to modify an instance of the configuration without permanently changing the original.
+     *
+     * @param configuration Existing configuration
+     *
+     */
+    public KafkaMirrorMaker2Configuration(KafkaMirrorMaker2Configuration configuration) {
+        super(configuration);
+    }
+
+    /**
      * Constructor used to instantiate this class from JsonObject. Should be used to
      * create configuration from ConfigMap / CRD.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2Connectors.java
@@ -9,6 +9,7 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScram;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha256;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporter;
 import io.strimzi.api.kafka.model.common.tracing.JaegerTracing;
 import io.strimzi.api.kafka.model.common.tracing.OpenTelemetryTracing;
 import io.strimzi.api.kafka.model.common.tracing.Tracing;
@@ -18,6 +19,7 @@ import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ConnectorSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpec;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterConfig;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.ReconciliationLogger;
 import io.strimzi.operator.common.model.InvalidResourceException;
@@ -70,6 +72,7 @@ public class KafkaMirrorMaker2Connectors {
     private final List<KafkaMirrorMaker2MirrorSpec> mirrors;
     private final Tracing tracing;
     private final boolean rackAwarenessEnabled;
+    private final boolean strimziMetricsReporterEnabled;
 
     /**
      * Constructor
@@ -83,6 +86,7 @@ public class KafkaMirrorMaker2Connectors {
         this.mirrors = kafkaMirrorMaker2.getSpec().getMirrors();
         this.tracing = kafkaMirrorMaker2.getSpec().getTracing();
         this.rackAwarenessEnabled = kafkaMirrorMaker2.getSpec().getRack() != null;
+        this.strimziMetricsReporterEnabled = kafkaMirrorMaker2.getSpec().getMetricsConfig() instanceof StrimziMetricsReporter;
     }
 
     /**
@@ -171,6 +175,7 @@ public class KafkaMirrorMaker2Connectors {
         return connectors;
     }
 
+    @SuppressWarnings("NPathComplexity")
     /* test */ Map<String, Object> prepareMirrorMaker2ConnectorConfig(KafkaMirrorMaker2MirrorSpec mirror, KafkaMirrorMaker2ConnectorSpec connector, KafkaMirrorMaker2ClusterSpec sourceCluster, KafkaMirrorMaker2ClusterSpec targetCluster) {
         Map<String, Object> config = new HashMap<>(connector.getConfig());
 
@@ -229,6 +234,13 @@ public class KafkaMirrorMaker2Connectors {
         if (rackAwarenessEnabled) {
             String clientRackKey = "consumer.client.rack";
             config.put(clientRackKey, "${strimzifile:" + CONNECT_CONFIG_FILE + ":" + clientRackKey + "}");
+        }
+
+        // metrics are collected into a single registry and exposed using the Kafka Connect listener,
+        // so we need to disable the listener here to avoid opening the default port (8080)
+        if (strimziMetricsReporterEnabled) {
+            config.put("metric.reporters", StrimziMetricsReporterConfig.KAFKA_CLASS);
+            config.put(StrimziMetricsReporterConfig.LISTENER_ENABLE, "false");
         }
 
         return config;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/ModelUtils.java
@@ -29,10 +29,13 @@ import io.strimzi.operator.common.model.Labels;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * ModelUtils is a utility class that holds generic static helper functions
@@ -374,5 +377,45 @@ public class ModelUtils {
             }
         }
         return errors;
+    }
+
+    /**
+     * Append list configuration values or create a new list configuration if missing.
+     * A list configuration can contain a comma separated list of values.
+     * Duplicated values are removed.
+     *
+     * @param kafkaConfig Kafka configuration.
+     * @param key List configuration key.
+     * @param values List configuration values.
+     */
+    public static void createOrAddListConfig(AbstractConfiguration kafkaConfig, String key, String values) {
+        if (kafkaConfig == null) {
+            throw new IllegalArgumentException("Configuration is required");
+        }
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("Configuration key is required");
+        }
+        if (values == null || values.isBlank()) {
+            throw new IllegalArgumentException("Configuration values are required");
+        }
+
+        String existingConfig = kafkaConfig.getConfigOption(key);
+        // using an ordered set to preserve ordering of the existing kafkaConfig value
+        Set<String> existingSet = existingConfig == null ? new LinkedHashSet<>() :
+                Arrays.stream(existingConfig.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        // we also preserve ordering for new values in case they are user-provided
+        Set<String> newValues = Arrays.stream(values.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        // add only new values
+        boolean updated = existingSet.addAll(newValues);
+        if (updated) {
+            String updatedConfig = String.join(",", existingSet);
+            kafkaConfig.setConfigOption(key, updatedConfig);
+        }
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterConfig.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/metrics/StrimziMetricsReporterConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.metrics;
+
+/**
+ * This class holds Strimzi Metrics Reporter and related configuration keys.
+ */
+public class StrimziMetricsReporterConfig {
+    /** KafkaMetricsReporter fully qualified class name. */
+    public static final String KAFKA_CLASS = "io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter";
+
+    /** YammerMetricsReporter fully qualified class name. */
+    public static final String YAMMER_CLASS = "io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter";
+
+    /** Enable HTTP listener (true/false). */
+    public static final String LISTENER_ENABLE = "prometheus.metrics.reporter.listener.enable";
+
+    /** Set listener endpoint (e.g. http://:8080). */
+    public static final String LISTENER = "prometheus.metrics.reporter.listener";
+
+    /** Set a comma separated list of regexes. */
+    public static final String ALLOW_LIST = "prometheus.metrics.reporter.allowlist";
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -35,6 +35,7 @@ import io.strimzi.kafka.oauth.server.ServerConfig;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
 import io.strimzi.operator.cluster.model.cruisecontrol.CruiseControlMetricsReporter;
 import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterConfig;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.cruisecontrol.CruiseControlConfigurationParameters;
@@ -237,9 +238,9 @@ public class KafkaBrokerConfigurationBuilderTest {
                 .build();
 
         assertThat(configuration, isEquivalent("node.id=2",
-                "prometheus.metrics.reporter.listener.enable=true",
-                "prometheus.metrics.reporter.listener=http://:" + MetricsModel.METRICS_PORT,
-                "prometheus.metrics.reporter.allowlist=kafka_log.*,kafka_network.*"));
+                StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true",
+                StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT,
+                StrimziMetricsReporterConfig.ALLOW_LIST + "=kafka_log.*,kafka_network.*"));
     }
 
     @ParallelTest
@@ -631,8 +632,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzifile.param.allowed.paths=/opt/kafka",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
-                "metric.reporters=io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter",
-                "kafka.metrics.reporters=io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"));
+                "metric.reporters=" + StrimziMetricsReporterConfig.KAFKA_CLASS,
+                "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
     }
 
 
@@ -651,8 +652,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "metric.reporters=" + CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER
-                        + ",io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter",
-                "kafka.metrics.reporters=io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"));
+                        + "," + StrimziMetricsReporterConfig.KAFKA_CLASS,
+                "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
     }
 
     @ParallelTest
@@ -671,8 +672,8 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
                 "metric.reporters=" + CruiseControlMetricsReporter.CRUISE_CONTROL_METRIC_REPORTER
                         + ",org.apache.kafka.common.metrics.JmxReporter"
-                        + ",io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter",
-                "kafka.metrics.reporters=io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"));
+                        + "," + StrimziMetricsReporterConfig.KAFKA_CLASS,
+                "kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
     }
 
     static Stream<Arguments> userConfigurationWithMetricsReporters() {
@@ -691,7 +692,7 @@ public class KafkaBrokerConfigurationBuilderTest {
                 + "config.providers.strimzienv.param.allowlist.pattern=.*\n"
                 + "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider\n"
                 + "config.providers.strimzifile.param.allowed.paths=/opt/kafka\n"
-                +  "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider\n"
+                + "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider\n"
                 + "config.providers.strimzidir.param.allowed.paths=/opt/kafka\n"
                 + "auto.create.topics.enable=false\n"
                 + "offsets.topic.replication.factor=3\n"
@@ -728,10 +729,10 @@ public class KafkaBrokerConfigurationBuilderTest {
                        expectedConfig
                                + "metric.reporters="
                                + "my.domain.CustomMetricReporter,"
-                               + "io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter\n"
+                               + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
                                + "kafka.metrics.reporters="
                                + "my.domain.CustomYammerMetricReporter,"
-                               + "io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"
+                               + StrimziMetricsReporterConfig.YAMMER_CLASS
                ),
                Arguments.of(userConfig, true, true, false,
                        expectedConfig
@@ -747,20 +748,20 @@ public class KafkaBrokerConfigurationBuilderTest {
                                + "metric.reporters="
                                + "my.domain.CustomMetricReporter,"
                                + "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter,"
-                               + "io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter\n"
+                               +  StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
                                + "kafka.metrics.reporters="
                                + "my.domain.CustomYammerMetricReporter,"
-                               + "io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"
+                               + StrimziMetricsReporterConfig.YAMMER_CLASS
                ),
                Arguments.of(userConfig, false, true, true,
                        expectedConfig
                                + "metric.reporters="
                                + "my.domain.CustomMetricReporter,"
                                + "org.apache.kafka.common.metrics.JmxReporter,"
-                               + "io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter\n"
+                               +  StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
                                + "kafka.metrics.reporters="
                                + "my.domain.CustomYammerMetricReporter,"
-                               + "io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"
+                               + StrimziMetricsReporterConfig.YAMMER_CLASS
                ),
                Arguments.of(userConfig, true, true, true,
                        expectedConfig
@@ -768,10 +769,10 @@ public class KafkaBrokerConfigurationBuilderTest {
                                + "my.domain.CustomMetricReporter,"
                                + "com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter,"
                                + "org.apache.kafka.common.metrics.JmxReporter,"
-                               + "io.strimzi.kafka.metrics.KafkaPrometheusMetricsReporter\n"
+                               + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
                                + "kafka.metrics.reporters="
                                + "my.domain.CustomYammerMetricReporter,"
-                               + "io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"));
+                               + StrimziMetricsReporterConfig.YAMMER_CLASS));
     }
 
     @ParameterizedTest
@@ -2625,11 +2626,11 @@ public class KafkaBrokerConfigurationBuilderTest {
     @ParallelTest
     public void testCreateOrAddListConfigDoesNotExists() {
         KafkaConfiguration config1 = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config1, "test-key", "test-value");
+        ModelUtils.createOrAddListConfig(config1, "test-key", "test-value");
         assertThat(config1.getConfigOption("test-key"), is("test-value"));
 
         KafkaConfiguration config2 = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config2, "test-key", "test-value-1,test-value-2");
+        ModelUtils.createOrAddListConfig(config2, "test-key", "test-value-1,test-value-2");
         assertThat(config2.getConfigOption("test-key"), is("test-value-1,test-value-2"));
     }
 
@@ -2638,12 +2639,12 @@ public class KafkaBrokerConfigurationBuilderTest {
         KafkaConfiguration config1 = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
         config1.setConfigOption("test-key", "test-value-1");
 
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config1, "test-key", "test-value-2");
+        ModelUtils.createOrAddListConfig(config1, "test-key", "test-value-2");
         assertThat(config1.getConfigOption("test-key"), is("test-value-1,test-value-2"));
 
         KafkaConfiguration config2 = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
         config2.setConfigOption("test-key", "test-value-1,test-value-2");
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config2, "test-key", "test-value-3");
+        ModelUtils.createOrAddListConfig(config2, "test-key", "test-value-3");
         assertThat(config2.getConfigOption("test-key"), is("test-value-1,test-value-2,test-value-3"));
     }
 
@@ -2651,12 +2652,12 @@ public class KafkaBrokerConfigurationBuilderTest {
     public void testCreateOrAddListConfigExistsAndContainsValue() {
         KafkaConfiguration config1 = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
         config1.setConfigOption("test-key", "test-value-1");
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config1, "test-key", "test-value-1");
+        ModelUtils.createOrAddListConfig(config1, "test-key", "test-value-1");
         assertThat(config1.getConfigOption("test-key"), is("test-value-1"));
 
         KafkaConfiguration config2 = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
         config2.setConfigOption("test-key", "test-value-1,test-value-2");
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config2, "test-key", "test-value-1");
+        ModelUtils.createOrAddListConfig(config2, "test-key", "test-value-1");
         assertThat(config2.getConfigOption("test-key"), is("test-value-1,test-value-2"));
     }
 
@@ -2664,7 +2665,7 @@ public class KafkaBrokerConfigurationBuilderTest {
     public void testCreateOrAddListConfigWithDuplicate() {
         KafkaConfiguration config = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
         config.setConfigOption("test-key", "test-value-1,test-value-1,test-value-2");
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config, "test-key", "test-value-3,test-value-3");
+        ModelUtils.createOrAddListConfig(config, "test-key", "test-value-3,test-value-3");
         assertThat(config.getConfigOption("test-key"), is("test-value-1,test-value-2,test-value-3"));
     }
 
@@ -2672,7 +2673,7 @@ public class KafkaBrokerConfigurationBuilderTest {
     public void testCreateOrAddListConfigOrdering() {
         KafkaConfiguration config = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
         config.setConfigOption("test-key", "test-value-2,test-value-1");
-        KafkaBrokerConfigurationBuilder.createOrAddListConfig(config, "test-key", "test-value-3,");
+        ModelUtils.createOrAddListConfig(config, "test-key", "test-value-3,");
         assertThat(config.getConfigOption("test-key"), is("test-value-2,test-value-1,test-value-3"));
     }
 
@@ -2681,7 +2682,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         KafkaConfiguration config = new KafkaConfiguration(Reconciliation.DUMMY_RECONCILIATION, Set.of());
         config.setConfigOption("test-key", "test-value-1,test-value-2");
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            KafkaBrokerConfigurationBuilder.createOrAddListConfig(null, "test-key", "test-value-3");
+            ModelUtils.createOrAddListConfig(null, "test-key", "test-value-3");
         });
 
         assertThat(exception.getMessage(), is(equalTo("Configuration is required")));
@@ -2693,7 +2694,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         config.setConfigOption("test-key", "test-value-1,test-value-2");
 
         Stream.of(null, "", " ")
-                .map(key -> assertThrows(IllegalArgumentException.class, () -> KafkaBrokerConfigurationBuilder.createOrAddListConfig(config, key, "test-value-3")))
+                .map(key -> assertThrows(IllegalArgumentException.class, () -> ModelUtils.createOrAddListConfig(config, key, "test-value-3")))
                 .forEach(e -> assertThat(e.getMessage(), is("Configuration key is required")
                 ));
     }
@@ -2704,7 +2705,7 @@ public class KafkaBrokerConfigurationBuilderTest {
         config.setConfigOption("test-key", "test-value-1,test-value-2");
 
         Stream.of(null, "", " ")
-                .map(value -> assertThrows(IllegalArgumentException.class, () -> KafkaBrokerConfigurationBuilder.createOrAddListConfig(config, "test-key", value)))
+                .map(value -> assertThrows(IllegalArgumentException.class, () -> ModelUtils.createOrAddListConfig(config, "test-key", value)))
                 .forEach(e -> assertThat(e.getMessage(), is("Configuration values are required")
                 ));
     }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -80,6 +80,8 @@ import io.strimzi.operator.cluster.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.model.jmx.JmxModel;
 import io.strimzi.operator.cluster.model.logging.LoggingModel;
 import io.strimzi.operator.cluster.model.metrics.JmxPrometheusExporterModel;
+import io.strimzi.operator.cluster.model.metrics.MetricsModel;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterConfig;
 import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.cluster.model.nodepools.NodePoolUtils;
 import io.strimzi.operator.common.Annotations;
@@ -304,7 +306,7 @@ public class KafkaClusterTest {
     }
 
     @ParallelTest
-    public void testStrimziMetricsReporterConfigs() {
+    public void testStrimziMetricsReporterConfig() {
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
@@ -324,9 +326,11 @@ public class KafkaClusterTest {
         assertThat(cms.size(), is(8));
 
         for (ConfigMap cm : cms) {
-            assertThat(cm.getData().toString(), containsString("kafka.metrics.reporters=io.strimzi.kafka.metrics.YammerPrometheusMetricsReporter"));
-            assertThat(cm.getData().toString(), containsString("prometheus.metrics.reporter.listener=http://:9404"));
-            assertThat(cm.getData().toString(), containsString("prometheus.metrics.reporter.allowlist=kafka_log.*,kafka_network.*"));
+            assertThat(cm.getData().toString(), containsString("metric.reporters=" + StrimziMetricsReporterConfig.KAFKA_CLASS));
+            assertThat(cm.getData().toString(), containsString("kafka.metrics.reporters=" + StrimziMetricsReporterConfig.YAMMER_CLASS));
+            assertThat(cm.getData().toString(), containsString(StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true"));
+            assertThat(cm.getData().toString(), containsString(StrimziMetricsReporterConfig.LISTENER + "=http://:" + MetricsModel.METRICS_PORT));
+            assertThat(cm.getData().toString(), containsString(StrimziMetricsReporterConfig.ALLOW_LIST + "=kafka_log.*,kafka_network.*"));
         }
 
         NetworkPolicy np = kc.generateNetworkPolicy(null, null);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaConnectConfigurationBuilderTest.java
@@ -16,12 +16,21 @@ import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticatio
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationScramSha512Builder;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTls;
 import io.strimzi.api.kafka.model.common.authentication.KafkaClientAuthenticationTlsBuilder;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
+import io.strimzi.api.kafka.model.connect.KafkaConnectSpecBuilder;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterConfig;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterModel;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.test.annotations.ParallelSuite;
 import io.strimzi.test.annotations.ParallelTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static io.strimzi.operator.cluster.TestUtils.IsEquivalent.isEquivalent;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -395,7 +404,7 @@ class KafkaConnectConfigurationBuilderTest {
     @ParallelTest
     public void testWithConfigProviders() {
         String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
-                .withUserConfigurations(null)
+                .withUserConfiguration(null, false, false)
                 .build();
 
         assertThat(configuration, isEquivalent(
@@ -410,8 +419,14 @@ class KafkaConnectConfigurationBuilderTest {
                 "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider",
                 "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider",
                 "config.providers.strimzidir.param.allowed.paths=/opt/kafka",
-                "config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider"
-        ));
+                "config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider",
+                "group.id=connect-cluster",
+                "offset.storage.topic=connect-cluster-offsets",
+                "config.storage.topic=connect-cluster-configs",
+                "status.storage.topic=connect-cluster-status",
+                "key.converter=org.apache.kafka.connect.json.JsonConverter",
+                "value.converter=org.apache.kafka.connect.json.JsonConverter")
+        );
     }
 
     @ParallelTest
@@ -422,7 +437,7 @@ class KafkaConnectConfigurationBuilderTest {
         KafkaConnectConfiguration configurations = new KafkaConnectConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet());
 
         String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
-                .withUserConfigurations(configurations)
+                .withUserConfiguration(configurations, false, false)
                 .build();
 
         assertThat(configuration, isEquivalent(
@@ -457,7 +472,7 @@ class KafkaConnectConfigurationBuilderTest {
         KafkaConnectConfiguration configurations = new KafkaConnectConfiguration(Reconciliation.DUMMY_RECONCILIATION, userConfiguration.entrySet());
 
         String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
-                .withUserConfigurations(configurations)
+                .withUserConfiguration(configurations, false, false)
                 .build();
 
         assertThat(configuration, isEquivalent(
@@ -513,5 +528,128 @@ class KafkaConnectConfigurationBuilderTest {
                 "admin.security.protocol=PLAINTEXT",
                 "plugin.path=/opt/kafka/plugins"
         ));
+    }
+
+    @ParallelTest
+    public void withStrimziMetricsReporter() {
+        StrimziMetricsReporterModel model = new StrimziMetricsReporterModel(
+                new KafkaConnectSpecBuilder()
+                .withMetricsConfig(new StrimziMetricsReporterBuilder()
+                    .withNewValues()
+                        .withAllowList("kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*")
+                    .endValues()
+                    .build())
+                .build(), List.of(".*"));
+
+        String configuration = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
+                .withStrimziMetricsReporter(model)
+                .build();
+
+        assertThat(configuration, isEquivalent(
+                "admin.security.protocol=PLAINTEXT",
+                "bootstrap.servers=my-cluster-kafka-bootstrap:9092",
+                "security.protocol=PLAINTEXT",
+                "producer.security.protocol=PLAINTEXT",
+                "consumer.security.protocol=PLAINTEXT",
+                StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true",
+                StrimziMetricsReporterConfig.LISTENER + "=http://:9404",
+                StrimziMetricsReporterConfig.ALLOW_LIST + "=kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*",
+                "admin." + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true",
+                "admin." + StrimziMetricsReporterConfig.LISTENER + "=http://:9404",
+                "admin." + StrimziMetricsReporterConfig.ALLOW_LIST + "=kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*",
+                "producer." + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true",
+                "producer." + StrimziMetricsReporterConfig.LISTENER + "=http://:9404",
+                "producer." + StrimziMetricsReporterConfig.ALLOW_LIST + "=kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*",
+                "consumer." + StrimziMetricsReporterConfig.LISTENER_ENABLE + "=true",
+                "consumer." + StrimziMetricsReporterConfig.LISTENER + "=http://:9404",
+                "consumer." + StrimziMetricsReporterConfig.ALLOW_LIST + "=kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*"
+        ));
+    }
+
+    static Stream<Arguments> userConfigurationWithMetricsReporters() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("metric.reporters", "my.domain.CustomMetricReporter");
+
+        KafkaConnectConfiguration userConfig = new KafkaConnectConfiguration(Reconciliation.DUMMY_RECONCILIATION, configMap.entrySet());
+        String expectedConfig = "admin.security.protocol=PLAINTEXT\n"
+                + "bootstrap.servers=my-cluster-kafka-bootstrap:9092\n"
+                + "consumer.security.protocol=PLAINTEXT\n"
+                + "config.providers.strimzidir.class=org.apache.kafka.common.config.provider.DirectoryConfigProvider\n"
+                + "config.providers.strimzidir.param.allowed.paths=/opt/kafka\n"
+                + "config.providers.strimzienv.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider\n"
+                + "config.providers.strimzienv.param.allowlist.pattern=.*\n"
+                + "config.providers.strimzifile.class=org.apache.kafka.common.config.provider.FileConfigProvider\n"
+                + "config.providers=strimzienv,strimzifile,strimzidir,strimzisecrets\n"
+                + "config.providers.strimzisecrets.class=io.strimzi.kafka.KubernetesSecretConfigProvider\n"
+                + "config.storage.topic=connect-cluster-configs\n"
+                + "key.converter=org.apache.kafka.connect.json.JsonConverter\n"
+                + "offset.storage.topic=connect-cluster-offsets\n"
+                + "producer.security.protocol=PLAINTEXT\n"
+                + "security.protocol=PLAINTEXT\n"
+                + "status.storage.topic=connect-cluster-status\n"
+                + "group.id=connect-cluster\n"
+                + "value.converter=org.apache.kafka.connect.json.JsonConverter\n";
+
+        // testing 4 combinations of 2 boolean values
+        return Stream.of(
+                Arguments.of(userConfig, false, false,
+                        expectedConfig
+                                + "metric.reporters="
+                                + "my.domain.CustomMetricReporter"
+                ),
+                Arguments.of(userConfig, true, false,
+                        expectedConfig
+                                + "metric.reporters="
+                                + "my.domain.CustomMetricReporter,"
+                                + "org.apache.kafka.common.metrics.JmxReporter\n"
+                                + "admin.metric.reporters="
+                                + "org.apache.kafka.common.metrics.JmxReporter\n"
+                                + "producer.metric.reporters="
+                                + "org.apache.kafka.common.metrics.JmxReporter\n"
+                                + "consumer.metric.reporters="
+                                + "org.apache.kafka.common.metrics.JmxReporter"
+                ),
+                Arguments.of(userConfig, false, true,
+                        expectedConfig
+                                + "metric.reporters="
+                                + "my.domain.CustomMetricReporter,"
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                                + "admin.metric.reporters="
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                                + "producer.metric.reporters="
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                                + "consumer.metric.reporters="
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                ),
+
+                Arguments.of(userConfig, true, true,
+                        expectedConfig
+                                + "metric.reporters="
+                                + "my.domain.CustomMetricReporter,"
+                                + "org.apache.kafka.common.metrics.JmxReporter,"
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                                + "admin.metric.reporters="
+                                + "org.apache.kafka.common.metrics.JmxReporter,"
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                                + "producer.metric.reporters="
+                                + "org.apache.kafka.common.metrics.JmxReporter,"
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                                + "consumer.metric.reporters="
+                                + "org.apache.kafka.common.metrics.JmxReporter,"
+                                + StrimziMetricsReporterConfig.KAFKA_CLASS + "\n"
+                ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("userConfigurationWithMetricsReporters")
+    public void testUserConfigurationWithMetricReporters(
+            KafkaConnectConfiguration userConfig,
+            boolean injectJmx,
+            boolean injectStrimzi,
+            String expectedConfig) {
+        String actualConfig = new KafkaConnectConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, BOOTSTRAP_SERVERS)
+                .withUserConfiguration(userConfig, injectJmx, injectStrimzi)
+                .build();
+        assertThat(actualConfig, isEquivalent(expectedConfig));
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaMirrorMaker2ConnectorsTest.java
@@ -6,6 +6,7 @@ package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.ConnectorState;
+import io.strimzi.api.kafka.model.common.metrics.StrimziMetricsReporterBuilder;
 import io.strimzi.api.kafka.model.connector.KafkaConnector;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2Builder;
@@ -13,6 +14,7 @@ import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2ClusterSpecBuilder;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpec;
 import io.strimzi.api.kafka.model.mirrormaker2.KafkaMirrorMaker2MirrorSpecBuilder;
+import io.strimzi.operator.cluster.model.metrics.StrimziMetricsReporterConfig;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.InvalidResourceException;
 import org.junit.jupiter.api.Test;
@@ -842,5 +844,40 @@ public class KafkaMirrorMaker2ConnectorsTest {
                         "prefix.ssl.truststore.type", "PKCS12",
                         "prefix.sasl.mechanism", "SCRAM-SHA-512",
                         "prefix.bootstrap.servers", "sourceClusterAlias.sourceNamespace.svc:9092"))));
+    }
+
+    @Test
+    public void testConnectorConfigurationWithStrimziMetricsReporter() {
+        KafkaMirrorMaker2 kmm2 = new KafkaMirrorMaker2Builder(KMM2)
+                .editSpec()
+                .withMetricsConfig(new StrimziMetricsReporterBuilder()
+                        .withNewValues()
+                            .withAllowList("kafka_connect_connector_metrics.*" + "kafka_connect_connector_task_metrics.*")
+                        .endValues()
+                        .build())
+                .endSpec()
+                .build();
+
+        KafkaMirrorMaker2Connectors connectors = KafkaMirrorMaker2Connectors.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kmm2);
+        Map<String, Object> config = connectors.prepareMirrorMaker2ConnectorConfig(kmm2.getSpec().getMirrors().get(0),
+                kmm2.getSpec().getMirrors().get(0).getSourceConnector(),
+                kmm2.getSpec().getClusters().get(0),
+                kmm2.getSpec().getClusters().get(1));
+
+        Map<String, Object> expected = new TreeMap<>();
+        expected.put("source.cluster.alias", "source");
+        expected.put("source.cluster.bootstrap.servers", "source:9092");
+        expected.put("source.cluster.security.protocol", "PLAINTEXT");
+        expected.put("target.cluster.alias", "target");
+        expected.put("target.cluster.bootstrap.servers", "target:9092");
+        expected.put("target.cluster.security.protocol", "PLAINTEXT");
+        expected.put("sync.topic.acls.enabled", "false");
+        expected.put("topics", "my-topic-.*");
+        expected.put("topics.exclude", "exclude-topic-.*");
+        expected.put("groups", "my-group-.*");
+        expected.put("groups.exclude", "exclude-group-.*");
+        expected.put("metric.reporters", StrimziMetricsReporterConfig.KAFKA_CLASS);
+        expected.put(StrimziMetricsReporterConfig.LISTENER_ENABLE, "false");
+        assertThat(new TreeMap<>(config), is(expected));
     }
 }

--- a/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
+++ b/docker-images/kafka-based/kafka/scripts/kafka_connect_run.sh
@@ -31,7 +31,7 @@ fi
 export LOG_DIR="$KAFKA_HOME"
 
 # Enable Prometheus JMX Exporter as Java agent
-if [ "$KAFKA_CONNECT_METRICS_ENABLED" = "true" ]; then
+if [ "$KAFKA_CONNECT_JMX_EXPORTER_ENABLED" = "true" ]; then
     KAFKA_OPTS="${KAFKA_OPTS} -javaagent:$(ls "$JMX_EXPORTER_HOME"/jmx_prometheus_javaagent*.jar)=9404:$KAFKA_HOME/custom-config/metrics-config.json"
     export KAFKA_OPTS
 fi

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2506,7 +2506,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |Authentication configuration for Kafka Connect.
 |config
 |map
-|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
+|The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols).
 |resources
 |https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#resourcerequirements-v1-core[ResourceRequirements]
 |The maximum limits for CPU and memory resources and the requested initial resources.
@@ -2533,7 +2533,7 @@ include::../api/io.strimzi.api.kafka.model.connect.KafkaConnectSpec.adoc[levelof
 |Configuration of the node label which will be used as the `client.rack` consumer configuration.
 |metricsConfig
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
-|Metrics configuration. Only `jmxPrometheusExporter` can be configured, as this component does not yet support `strimziMetricsReporter`.
+|Metrics configuration.
 |tracing
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |The configuration of tracing in Kafka Connect.
@@ -4185,7 +4185,7 @@ Used in: xref:type-KafkaMirrorMaker2-{context}[`KafkaMirrorMaker2`]
 |Configuration of the node label which will be used as the `client.rack` consumer configuration.
 |metricsConfig
 |xref:type-JmxPrometheusExporterMetrics-{context}[`JmxPrometheusExporterMetrics`], xref:type-StrimziMetricsReporter-{context}[`StrimziMetricsReporter`]
-|Metrics configuration. Only `jmxPrometheusExporter` can be configured, as this component does not yet support `strimziMetricsReporter`.
+|Metrics configuration.
 |tracing
 |xref:type-JaegerTracing-{context}[`JaegerTracing`], xref:type-OpenTelemetryTracing-{context}[`OpenTelemetryTracing`]
 |The configuration of tracing in Kafka Connect.

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-connect-strimzi-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-connect-strimzi-metrics.yaml
@@ -1,0 +1,15 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  labels:
+    app: my-connect-cluster
+spec:
+  version: 4.0.0
+  replicas: 1
+  bootstrapServers: my-cluster-kafka-bootstrap:9092
+  metricsConfig:
+    type: strimziMetricsReporter
+    values:
+      allowList:
+        - kafka_connect_connector_metrics.*

--- a/packaging/examples/metrics/strimzi-metrics-reporter/kafka-mirror-maker-2-Strimzi-metrics.yaml
+++ b/packaging/examples/metrics/strimzi-metrics-reporter/kafka-mirror-maker-2-Strimzi-metrics.yaml
@@ -1,0 +1,41 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaMirrorMaker2
+metadata:
+  name: my-mm2-cluster
+  labels:
+    app: my-mm2-cluster
+spec:
+  version: 4.0.0
+  replicas: 1
+  connectCluster: "my-cluster-target"
+  clusters:
+    - alias: "my-cluster-source"
+      bootstrapServers: my-cluster-source-kafka-bootstrap:9092
+    - alias: "my-cluster-target"
+      bootstrapServers: my-cluster-target-kafka-bootstrap:9092
+      config:
+        # -1 means it will use the default replication factor configured in the broker
+        config.storage.replication.factor: -1
+        offset.storage.replication.factor: -1
+        status.storage.replication.factor: -1
+  mirrors:
+    - sourceCluster: "my-cluster-source"
+      targetCluster: "my-cluster-target"
+      sourceConnector:
+        config:
+          # -1 means it will use the default replication factor configured in the broker
+          replication.factor: -1
+          offset-syncs.topic.replication.factor: -1
+          sync.topic.acls.enabled: "false"
+      heartbeatConnector:
+        config:
+          # -1 means it will use the default replication factor configured in the broker
+          heartbeats.topic.replication.factor: -1
+      checkpointConnector:
+        config:
+          # -1 means it will use the default replication factor configured in the broker
+          checkpoints.topic.replication.factor: -1
+      topicsPattern: ".*"
+      groupsPattern: ".*"
+  metricsConfig:
+    type: strimziMetricsReporter

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
@@ -278,7 +278,7 @@ spec:
                 config:
                   x-kubernetes-preserve-unknown-fields: true
                   type: object
-                  description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                  description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
                 resources:
                   type: object
                   properties:
@@ -481,12 +481,10 @@ spec:
                       description: Configuration values for the Strimzi Metrics Reporter.
                   required:
                     - type
-                  description: "Metrics configuration. Only `jmxPrometheusExporter` can be configured, as this component does not yet support `strimziMetricsReporter`."
+                  description: Metrics configuration.
                   x-kubernetes-validations:
                     - rule: self.type != 'jmxPrometheusExporter' || has(self.valueFrom)
                       message: valueFrom property is required
-                    - rule: self.type != 'strimziMetricsReporter'
-                      message: value type not supported
                 tracing:
                   type: object
                   properties:

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
@@ -698,12 +698,10 @@ spec:
                       description: Configuration values for the Strimzi Metrics Reporter.
                   required:
                     - type
-                  description: "Metrics configuration. Only `jmxPrometheusExporter` can be configured, as this component does not yet support `strimziMetricsReporter`."
+                  description: Metrics configuration.
                   x-kubernetes-validations:
                     - rule: self.type != 'jmxPrometheusExporter' || has(self.valueFrom)
                       message: valueFrom property is required
-                    - rule: self.type != 'strimziMetricsReporter'
-                      message: value type not supported
                 tracing:
                   type: object
                   properties:

--- a/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
+++ b/packaging/install/cluster-operator/041-Crd-kafkaconnect.yaml
@@ -277,7 +277,7 @@ spec:
               config:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
-                description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
+                description: "The Kafka Connect configuration. Properties with the following prefixes cannot be set: ssl., sasl., security., listeners, plugin.path, rest., bootstrap.servers, consumer.interceptor.classes, producer.interceptor.classes, prometheus.metrics.reporter. (with the exception of: ssl.endpoint.identification.algorithm, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols)."
               resources:
                 type: object
                 properties:
@@ -480,12 +480,10 @@ spec:
                     description: Configuration values for the Strimzi Metrics Reporter.
                 required:
                 - type
-                description: "Metrics configuration. Only `jmxPrometheusExporter` can be configured, as this component does not yet support `strimziMetricsReporter`."
+                description: Metrics configuration.
                 x-kubernetes-validations:
                 - rule: self.type != 'jmxPrometheusExporter' || has(self.valueFrom)
                   message: valueFrom property is required
-                - rule: self.type != 'strimziMetricsReporter'
-                  message: value type not supported
               tracing:
                 type: object
                 properties:

--- a/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
+++ b/packaging/install/cluster-operator/048-Crd-kafkamirrormaker2.yaml
@@ -697,12 +697,10 @@ spec:
                     description: Configuration values for the Strimzi Metrics Reporter.
                 required:
                 - type
-                description: "Metrics configuration. Only `jmxPrometheusExporter` can be configured, as this component does not yet support `strimziMetricsReporter`."
+                description: Metrics configuration.
                 x-kubernetes-validations:
                 - rule: self.type != 'jmxPrometheusExporter' || has(self.valueFrom)
                   message: valueFrom property is required
-                - rule: self.type != 'strimziMetricsReporter'
-                  message: value type not supported
               tracing:
                 type: object
                 properties:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature


### Description
This patch adds support for the Strimzi Metrics Reporter to Kafka Connect and MirrorMaker2 as described by the following proposal:

https://github.com/strimzi/proposals/blob/main/064-prometheus-metrics-reporter.md

Related to #10753

We won’t initially support the CruiseControl component. To make it work, CC should be changed to expose metrics through its HTTP endpoint.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md